### PR TITLE
PhysicalFileSystemCache can now choose to check the source for changes

### DIFF
--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -46,25 +46,32 @@ namespace SixLabors.ImageSharp.Web.Sample
             //        .AddProcessor<ResizeWebProcessor>();
 
 
-            //// Or we can fine-grain control adding custom options and configure all other services.
+            //// Or we can fine-grain control adding custom options and configure all other services
+            //// There are also factory methods for each builder that will allow building from configuration files.
             //services.AddImageSharpCore(
-            //        options =>
+            //    options =>
+            //        {
+            //            options.Configuration = Configuration.Default;
+            //            options.MaxBrowserCacheDays = 7;
+            //            options.MaxCacheDays = 365;
+            //            options.OnValidate = _ => { };
+            //            options.OnBeforeSave = _ => { };
+            //            options.OnProcessed = _ => { };
+            //            options.OnPrepareResponse = _ => { };
+            //        })
+            //    .SetUriParser<QueryCollectionUriParser>()
+            //    .SetCache(
+            //        provider => new PhysicalFileSystemCache(provider.GetRequiredService<IHostingEnvironment>())
+            //        {
+            //            Settings =
             //            {
-            //                options.Configuration = Configuration.Default;
-            //                options.MaxBrowserCacheDays = 7;
-            //                options.MaxCacheDays = 365;
-            //                options.OnValidate = _ => { };
-            //                options.OnBeforeSave = _ => { };
-            //                options.OnProcessed = _ => { };
-            //                options.OnPrepareResponse = _ => { };
-            //            })
-            //        .SetUriParser<QueryCollectionUriParser>()
-            //        .SetCache<PhysicalFileSystemCache>()
-            //        .SetAsyncKeyLock<AsyncKeyLock>()
-            //        .AddResolver<PhysicalFileSystemResolver>()
-            //        .AddProcessor<ResizeWebProcessor>();
-
-            // There are also factory methods for each builder that will allow building from configuration files.
+            //                new KeyValuePair<string, string>( PhysicalFileSystemCache.Folder, PhysicalFileSystemCache.DefaultCacheFolder),
+            //                new KeyValuePair<string, string>( PhysicalFileSystemCache.CheckSourceChanged, "true")
+            //            }
+            //        })
+            //    .SetAsyncKeyLock<AsyncKeyLock>()
+            //    .AddResolver<PhysicalFileSystemResolver>()
+            //    .AddProcessor<ResizeWebProcessor>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/ImageSharp.Web/Caching/CachedInfo.cs
+++ b/src/ImageSharp.Web/Caching/CachedInfo.cs
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            return obj is CachedInfo && this.Equals((CachedInfo)obj);
+            return obj is CachedInfo info && this.Equals(info);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp.Web/Caching/IImageCache.cs
+++ b/src/ImageSharp.Web/Caching/IImageCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace SixLabors.ImageSharp.Web.Caching
 {
@@ -28,13 +29,14 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <summary>
         /// Returns a value indicating whether the current cached item is expired.
         /// </summary>
+        /// <param name="context">The current HTTP request context</param>
         /// <param name="key">The cache key</param>
         /// <param name="minDateUtc">
         /// The minimum allowable date and time in coordinated universal time (UTC) since the file was last modified.
         /// Calculated as the current datetime minus the maximum allowable cached days.
         /// </param>
         /// <returns>The <see cref="Task{ImageCacheInfo}"/></returns>
-        Task<CachedInfo> IsExpiredAsync(string key, DateTime minDateUtc);
+        Task<CachedInfo> IsExpiredAsync(HttpContext context, string key, DateTime minDateUtc);
 
         /// <summary>
         /// Sets the value associated with the specified key.

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpCoreBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpCoreBuilderExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
-using SixLabors.ImageSharp.Web.Helpers;
 using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Resolvers;
 

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
@@ -24,9 +24,9 @@ namespace SixLabors.ImageSharp.Web.Resolvers
     public class PhysicalFileSystemResolver : IImageResolver
     {
         /// <summary>
-        /// The hosting environment the application is running in.
+        /// The file provider abstraction.
         /// </summary>
-        private readonly IHostingEnvironment environment;
+        private readonly IFileProvider fileProvider;
 
         /// <summary>
         /// The middleware configuration options.
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         /// <param name="options">The middleware configuration options</param>
         public PhysicalFileSystemResolver(IHostingEnvironment environment, IOptions<ImageSharpMiddlewareOptions> options)
         {
-            this.environment = environment;
+            this.fileProvider = environment.WebRootFileProvider;
             this.options = options.Value;
         }
 
@@ -60,8 +60,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         public async Task<byte[]> ResolveImageAsync(HttpContext context, ILogger logger)
         {
             // Path has already been correctly parsed before here.
-            IFileProvider fileProvider = this.environment.WebRootFileProvider;
-            IFileInfo fileInfo = fileProvider.GetFileInfo(context.Request.Path);
+            IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path);
             byte[] buffer;
 
             // Check to see if the file exists.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
THis PR adds the optional ability to the `PhysicalFileSystemCache` to check the source file for any changes since the last request. This means that someone can replace an image with an updated one with the same name and the cache will automatically update the cached result to match.

By default this is off since it adds overhead to the request. Turning the functionality on is performed in the following manner:

``` c#
services.AddImageSharpCore()
     .SetCache(
        provider => new PhysicalFileSystemCache(provider.GetRequiredService<IHostingEnvironment>())
        {
            Settings =
            {
                new KeyValuePair<string, string>( PhysicalFileSystemCache.Folder, PhysicalFileSystemCache.DefaultCacheFolder),
                new KeyValuePair<string, string>( PhysicalFileSystemCache.CheckSourceChanged, "true")
            }
        });
```

<!-- Thanks for contributing to ImageSharp! -->
