### PR TITLE
UrlDecode request path

### DIFF
--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -101,7 +101,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             // Checking the source adds overhead but is configurable. Defaults to false
             if (checkSource)
             {
-                IFileInfo sourceFileInfo = this.fileProvider.GetFileInfo(WebUtility.UrlDecode(context.Request.Path));
+                IFileInfo sourceFileInfo = this.fileProvider.GetFileInfo(context.Request.Path.Value);
 
                 if (!sourceFileInfo.Exists)
                 {

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -100,7 +101,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             // Checking the source adds overhead but is configurable. Defaults to false
             if (checkSource)
             {
-                IFileInfo sourceFileInfo = this.fileProvider.GetFileInfo(context.Request.Path);
+                IFileInfo sourceFileInfo = this.fileProvider.GetFileInfo(WebUtility.UrlDecode(context.Request.Path));
 
                 if (!sourceFileInfo.Exists)
                 {

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -11,7 +12,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Web.Helpers;
 using SixLabors.ImageSharp.Web.Memory;
 using SixLabors.ImageSharp.Web.Middleware;
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         public async Task<byte[]> ResolveImageAsync(HttpContext context, ILogger logger)
         {
             // Path has already been correctly parsed before here.
-            IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path);
+            IFileInfo fileInfo = this.fileProvider.GetFileInfo(WebUtility.UrlDecode(context.Request.Path));
             byte[] buffer;
 
             // Check to see if the file exists.

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
@@ -60,7 +60,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         public async Task<byte[]> ResolveImageAsync(HttpContext context, ILogger logger)
         {
             // Path has already been correctly parsed before here.
-            IFileInfo fileInfo = this.fileProvider.GetFileInfo(WebUtility.UrlDecode(context.Request.Path));
+            IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path.Value);
             byte[] buffer;
 
             // Check to see if the file exists.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #10 Turns out we weren't Url decoding the request path before checking it using a FileInfo. 

No specific tests yet as we need to finish fleshing out the tests first.

<!-- Thanks for contributing to ImageSharp! -->
