### PR TITLE
Improve/fix FormatHelpers.GetExtension URI parsing

### DIFF
--- a/src/ImageSharp.Web/Helpers/FormatHelpers.cs
+++ b/src/ImageSharp.Web/Helpers/FormatHelpers.cs
@@ -64,11 +64,6 @@ namespace SixLabors.ImageSharp.Web.Helpers
                 }
             }
 
-            if (extension != null && !path.EndsWith(extension))
-            {
-                return null;
-            }
-
             return extension;
         }
 

--- a/src/ImageSharp.Web/Helpers/FormatHelpers.cs
+++ b/src/ImageSharp.Web/Helpers/FormatHelpers.cs
@@ -6,8 +6,8 @@ using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Web.Processors;
 
 namespace SixLabors.ImageSharp.Web.Helpers
 {
@@ -39,8 +39,7 @@ namespace SixLabors.ImageSharp.Web.Helpers
             string[] parts = uri.Split('?');
             if (parts.Length > 1)
             {
-                StringValues ext;
-                if (QueryHelpers.ParseQuery(parts[1]).TryGetValue("format", out ext))
+                if (QueryHelpers.ParseQuery(parts[1]).TryGetValue(FormatWebProcessor.Format, out StringValues ext))
                 {
                     return ext;
                 }

--- a/tests/ImageSharp.Web.Tests/Helpers/FormatHelpersTests.cs
+++ b/tests/ImageSharp.Web.Tests/Helpers/FormatHelpersTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SixLabors.ImageSharp.Web.Helpers;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Helpers
+{
+    public class FormatHelpersTests
+    {
+        public static IEnumerable<object[]> DefaultExtensions = 
+            Configuration.Default.ImageFormats.SelectMany(f => f.FileExtensions.Select(e => new object[] { e, e }));
+
+        [Theory]
+        [MemberData(nameof(DefaultExtensions))]
+        public void GetExtensionShouldMatchDefaultExtensions(string expected, string ext)
+        {
+            string uri = $"http://www.example.org/some/path/to/image.{ext}?width=300";
+            Assert.Equal(expected, FormatHelpers.GetExtension(Configuration.Default, uri));
+        }
+
+        [Fact]
+        public void GetExtensionShouldNotMatchExtensionWithoutDotPrefix()
+        {
+            string uri = "http://www.example.org/some/path/to/bmpimage";
+            Assert.Null(FormatHelpers.GetExtension(Configuration.Default, uri));
+        }
+
+        [Fact]
+        public void GetExtensionShouldIgnoreQueryString()
+        {
+            string uri = "http://www.example.org/some/path/to/image.bmp?width=300&foo=.png";
+            Assert.Equal("bmp", FormatHelpers.GetExtension(Configuration.Default, uri));
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Helpers/FormatHelpersTests.cs
+++ b/tests/ImageSharp.Web.Tests/Helpers/FormatHelpersTests.cs
@@ -28,10 +28,17 @@ namespace SixLabors.ImageSharp.Web.Tests.Helpers
         }
 
         [Fact]
-        public void GetExtensionShouldIgnoreQueryString()
+        public void GetExtensionShouldIgnoreQueryStringWithoutFormatParamter()
         {
             string uri = "http://www.example.org/some/path/to/image.bmp?width=300&foo=.png";
             Assert.Equal("bmp", FormatHelpers.GetExtension(Configuration.Default, uri));
+        }
+
+        [Fact]
+        public void GetExtensionShouldAcknowledgeQueryStringFormatParameter()
+        {
+            string uri = "http://www.example.org/some/path/to/image.bmp?width=300&format=png";
+            Assert.Equal("png", FormatHelpers.GetExtension(Configuration.Default, uri));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This is related to https://github.com/OrchardCMS/OrchardCore/issues/1472

I've made some changes to the FormatHelpers.GetExtension method to make it "safer":
- At first it checks the query string for the "format" parameter, then it searches the path of the URI for a known file extension.
- It only matches an extension preceeded by a dot.
- It now correctly selects the most matching extension in case of multiple extensions with the same character sequence, for example "bm" and "bmp". Previously it would match "bm" even if the URI contained "bmp".
