### PR TITLE
Add command filtering before OnValidate is called.

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -125,10 +125,13 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <returns>The <see cref="Task"/></returns>
         public async Task Invoke(HttpContext context)
         {
-            IDictionary<string, string> commands = this.uriParser.ParseUriCommands(context);
+            IDictionary<string, string> commands = this.uriParser.ParseUriCommands(context)
+                .Where(kvp => this.knownCommands.Contains(kvp.Key))
+                .ToDictionary(p => p.Key, p => p.Value);
+
             this.options.OnValidate?.Invoke(new ImageValidationContext(context, commands, CommandParser.Instance));
 
-            if (!commands.Any() || !commands.Keys.Intersect(this.knownCommands).Any())
+            if (!commands.Any())
             {
                 // Nothing to do. call the next delegate/middleware in the pipeline
                 await this.next(context);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This is related to https://github.com/OrchardCMS/OrchardCore/issues/1472

A proposal to filter the commands dictionary before supplying it to the OnValidate option. 
