### PR TITLE
Improve file resolving and caching

### DIFF
--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -7,9 +7,11 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.DependencyInjection;
+using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Resolvers;
 
@@ -31,6 +33,7 @@ namespace SixLabors.ImageSharp.Web.Sample
             //            options.Configuration = Configuration.Default;
             //            options.MaxBrowserCacheDays = 7;
             //            options.MaxCacheDays = 365;
+            //            options.CacheDepth = 8;
             //            options.OnValidate = _ => { };
             //            options.OnBeforeSave = _ => { };
             //            options.OnProcessed = _ => { };
@@ -41,6 +44,7 @@ namespace SixLabors.ImageSharp.Web.Sample
             //services.AddImageSharpCore()
             //        .SetUriParser<QueryCollectionUriParser>()
             //        .SetCache<PhysicalFileSystemCache>()
+            //        .SetCacheHash<CacheHash>()
             //        .SetAsyncKeyLock<AsyncKeyLock>()
             //        .AddResolver<PhysicalFileSystemResolver>()
             //        .AddProcessor<ResizeWebProcessor>();
@@ -54,6 +58,7 @@ namespace SixLabors.ImageSharp.Web.Sample
             //            options.Configuration = Configuration.Default;
             //            options.MaxBrowserCacheDays = 7;
             //            options.MaxCacheDays = 365;
+            //            options.CachedNameLength = 8;
             //            options.OnValidate = _ => { };
             //            options.OnBeforeSave = _ => { };
             //            options.OnProcessed = _ => { };
@@ -61,14 +66,17 @@ namespace SixLabors.ImageSharp.Web.Sample
             //        })
             //    .SetUriParser<QueryCollectionUriParser>()
             //    .SetCache(
-            //        provider => new PhysicalFileSystemCache(provider.GetRequiredService<IHostingEnvironment>())
-            //        {
-            //            Settings =
+            //        provider => new PhysicalFileSystemCache(
+            //            provider.GetRequiredService<IHostingEnvironment>(),
+            //            provider.GetRequiredService<IOptions<ImageSharpMiddlewareOptions>>())
             //            {
-            //                new KeyValuePair<string, string>( PhysicalFileSystemCache.Folder, PhysicalFileSystemCache.DefaultCacheFolder),
-            //                new KeyValuePair<string, string>( PhysicalFileSystemCache.CheckSourceChanged, "true")
-            //            }
-            //        })
+            //                Settings =
+            //                {
+            //                    new KeyValuePair<string, string>( PhysicalFileSystemCache.Folder, PhysicalFileSystemCache.DefaultCacheFolder),
+            //                    new KeyValuePair<string, string>( PhysicalFileSystemCache.CheckSourceChanged, "true")
+            //                }
+            //            })
+            //    .SetCacheHash<CacheHash>()
             //    .SetAsyncKeyLock<AsyncKeyLock>()
             //    .AddResolver<PhysicalFileSystemResolver>()
             //    .AddProcessor<ResizeWebProcessor>();

--- a/src/ImageSharp.Web/Caching/CacheHash.cs
+++ b/src/ImageSharp.Web/Caching/CacheHash.cs
@@ -3,120 +3,47 @@
 
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp.Web.Helpers;
+using SixLabors.ImageSharp.Web.Middleware;
 
 namespace SixLabors.ImageSharp.Web.Caching
 {
     /// <summary>
-    /// Creates hashed keys for the given inputs.
-    /// Hashed keys are the result of Base32 encoding the SHA256 computation of the input value.
-    /// This helps ensure compressable values with low collision rates.
+    /// Creates hashed keys for the given inputs hashing them to string of length ranging from 2 to 64.
+    /// Hashed keys are the result of the SHA256 computation of the input value for the given length.
+    /// This ensures low collision rates with a shorter file name.
     /// </summary>
-    internal static class CacheHash
+    public sealed class CacheHash : ICacheHash
     {
-        /// <summary>
-        /// The Base32 Alphabet
-        /// </summary>
-        private static readonly char[] Base32Table =
-        {
-            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-            'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '2', '3', '4', '5', '6', '7'
-        };
+        private readonly ImageSharpMiddlewareOptions options;
 
         /// <summary>
-        /// Create a cache key based on the given string.
+        /// Initializes a new instance of the <see cref="CacheHash"/> class.
         /// </summary>
-        /// <param name="data">The data to create a key for.</param>
-        /// <param name="configuration">The library configuration.</param>
-        /// <returns>The hashed <see cref="string"/></returns>
-        public static string Create(string data, Configuration configuration) => ComputeHash(data, configuration);
-
-        /// <summary>
-        /// Computes a hashed value for the given uri string.
-        /// </summary>
-        /// <param name="uri">The uri to hash.</param>
-        /// <param name="configuration">The library configuration.</param>
-        /// <returns>The hashed <see cref="string"/></returns>
-        public static string ComputeHash(string uri, Configuration configuration)
+        /// <param name="options">The middleware configuration options</param>
+        public CacheHash(IOptions<ImageSharpMiddlewareOptions> options)
         {
-            using (var hashAlgorithm = SHA256.Create())
-            {
-                return $"{Encode(hashAlgorithm.ComputeHash(Encoding.ASCII.GetBytes(uri)))}.{FormatHelpers.GetExtensionOrDefault(configuration, uri)}";
-            }
+            this.options = options.Value;
         }
 
-        /// <summary>
-        /// Returns a Base32 encoded string representation of the given hash.
-        /// <see href="https://tools.ietf.org/html/rfc4648#section-6"/>
-        /// </summary>
-        /// <param name="hash">The hash.</param>
-        /// <returns>The Base32 encoded <see cref="string"/></returns>
-        private static string Encode(byte[] hash)
+        /// <inheritdoc/>
+        public string Create(string value, uint length)
         {
-            // TODO: Write unit tests for this using http://www.simplycalc.com/base32-encode.php as a basis.
-            const char Pad = '=';
-            char[] b32 = Base32Table;
-            int length = hash.Length;
-            char[] result = new char[length + 7];
-            int i;
-
-            for (i = 0; i <= length - 5; i += 5)
+            Guard.MustBeBetweenOrEqualTo<uint>(length, 2, 64, nameof(length));
+            using (var hashAlgorithm = SHA256.Create())
             {
-                result[i] = b32[hash[i] >> 3];
-                result[i + 1] = b32[((hash[i] & 0x07) << 2) | (hash[i + 1] >> 6)];
-                result[i + 2] = b32[(hash[i + 1] & 0x3E) >> 1];
-                result[i + 3] = b32[((hash[i + 1] & 0x01) << 4) | (hash[i + 2] >> 4)];
-                result[i + 4] = b32[((hash[i + 2] & 0x0F) << 1) | (hash[i + 3] >> 7)];
-                result[i + 5] = b32[(hash[i + 3] & 0x7C) >> 2];
-                result[i + 6] = b32[((hash[i + 3] & 0x03) << 3) | ((hash[i + 4] & 0xE0) >> 5)];
-                result[i + 7] = b32[hash[i + 4] & 0x1F];
-            }
+                // Concatenate the hash bytes into one long String.
+                int len = (int)length;
+                byte[] hash = hashAlgorithm.ComputeHash(Encoding.ASCII.GetBytes(value));
+                var sb = new StringBuilder(len);
+                for (int i = 0; i < len / 2; i++)
+                {
+                    sb.Append(hash[i].ToString("X2"));
+                }
 
-            switch (length % 5)
-            {
-                case 4:
-                    result[i + 1] = b32[hash[i] >> 3];
-                    result[i + 2] = b32[((hash[i] & 0x07) << 2) | (hash[i + 1] >> 6)];
-                    result[i + 3] = b32[(hash[i + 1] & 0x3E) >> 1];
-                    result[i + 4] = b32[((hash[i + 1] & 0x01) << 4) | (hash[i + 2] >> 4)];
-                    result[i + 5] = b32[((hash[i + 2] & 0x0F) << 1) | (hash[i + 3] >> 7)];
-                    result[i + 6] = b32[(hash[i + 3] & 0x7C) >> 2];
-                    result[i + 7] = b32[(hash[i + 3] & 0x03) << 3];
-                    result[i + 8] = Pad;
-                    break;
-                case 3:
-                    result[i + 1] = b32[hash[i] >> 3];
-                    result[i + 2] = b32[((hash[i] & 0x07) << 2) | (hash[i + 1] >> 6)];
-                    result[i + 3] = b32[(hash[i + 1] & 0x3E) >> 1];
-                    result[i + 4] = b32[((hash[i + 1] & 0x01) << 4) | (hash[i + 2] >> 4)];
-                    result[i + 5] = b32[(hash[i + 2] & 0x0F) << 1];
-                    result[i + 6] = Pad;
-                    result[i + 7] = Pad;
-                    result[i + 8] = Pad;
-                    break;
-                case 2:
-                    result[i + 1] = b32[hash[i] >> 3];
-                    result[i + 2] = b32[((hash[i] & 0x07) << 2) | (hash[i + 1] >> 6)];
-                    result[i + 3] = b32[(hash[i + 1] & 0x3E) >> 1];
-                    result[i + 4] = b32[(hash[i + 1] & 0x01) << 4];
-                    result[i + 5] = Pad;
-                    result[i + 6] = Pad;
-                    result[i + 7] = Pad;
-                    result[i + 8] = Pad;
-                    break;
-                case 1:
-                    result[i + 1] = b32[hash[i] >> 3];
-                    result[i + 2] = b32[(hash[i] & 7) << 2];
-                    result[i + 3] = Pad;
-                    result[i + 4] = Pad;
-                    result[i + 5] = Pad;
-                    result[i + 6] = Pad;
-                    result[i + 7] = Pad;
-                    result[i + 8] = Pad;
-                    break;
+                return $"{sb}.{FormatHelpers.GetExtensionOrDefault(this.options.Configuration, value)}";
             }
-
-            return new string(result);
         }
     }
 }

--- a/src/ImageSharp.Web/Caching/DoormanPool.cs
+++ b/src/ImageSharp.Web/Caching/DoormanPool.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// Retrieves a <see cref="Doorman"/> from the pool or a new one if the pool is empty
         /// </summary>
         /// <returns>Tre <see cref="Doorman"/></returns>
-        public static Doorman Rent() => Pool.TryTake(out var doorman) ? doorman : new Doorman();
+        public static Doorman Rent() => Pool.TryTake(out Doorman doorman) ? doorman : new Doorman();
 
         /// <summary>
         /// Returns an doorman to the pool that was previously obtained using the <see cref="Rent"></see>

--- a/src/ImageSharp.Web/Caching/ICacheHash.cs
+++ b/src/ImageSharp.Web/Caching/ICacheHash.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Web.Caching
+{
+    /// <summary>
+    /// Defines a contract that allows the creation of hashed file names for storing cached images.
+    /// </summary>
+    public interface ICacheHash
+    {
+        /// <summary>
+        /// Returns the hashed file name for the cached image file.
+        /// </summary>
+        /// <param name="value">The input value to hash</param>
+        /// <param name="length">The length of the returned hash without any extensions</param>
+        /// <returns>The <see cref="string"/></returns>
+        string Create(string value, uint length);
+    }
+}

--- a/src/ImageSharp.Web/Caching/IImageCache.cs
+++ b/src/ImageSharp.Web/Caching/IImageCache.cs
@@ -6,18 +6,18 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
+// TODO: Do we add cleanup to this? Scalable caches probably shouldn't do so.
 namespace SixLabors.ImageSharp.Web.Caching
 {
     /// <summary>
     /// Specifies the contract for caching images.
-    /// TODO: Do we add cleanup to this? Scalable caches probably shouldn't do so.
     /// </summary>
     public interface IImageCache
     {
         /// <summary>
-        /// Gets or sets any additional settings.
+        /// Gets any additional settings.
         /// </summary>
-        IDictionary<string, string> Settings { get; set; }
+        IDictionary<string, string> Settings { get; }
 
         /// <summary>
         /// Gets the value associated with the specified key.

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpConfiguration.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpConfiguration.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0.
 
 using Microsoft.Extensions.Options;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Middleware;
 
 namespace SixLabors.ImageSharp.Web.DependencyInjection
 {
     /// <summary>
-    /// Provides default configuration settings to be consumeed by the middleware
+    /// Provides default configuration settings to be consumed by the middleware
     /// </summary>
     public class ImageSharpConfiguration : IConfigureOptions<ImageSharpMiddlewareOptions>
     {
@@ -18,6 +17,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
             options.Configuration = Configuration.Default;
             options.MaxCacheDays = 365;
             options.MaxBrowserCacheDays = 7;
+            options.CachedNameLength = 12;
         }
     }
 }

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpCoreBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpCoreBuilderExtensions.cs
@@ -71,6 +71,33 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         }
 
         /// <summary>
+        /// Sets the given <see cref="ICacheHash"/> adding it to the service collection
+        /// </summary>
+        /// <typeparam name="TCacheHash">The type of class implementing <see cref="ICacheHash"/>to add.</typeparam>
+        /// <param name="builder">The <see cref="IImageSharpCoreBuilder"/></param>
+        /// <returns>The <see cref="IImageSharpCoreBuilder"/>.</returns>
+        public static IImageSharpCoreBuilder SetCacheHash<TCacheHash>(this IImageSharpCoreBuilder builder)
+            where TCacheHash : class, ICacheHash
+        {
+            builder.Services.AddSingleton<ICacheHash, TCacheHash>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Sets the given <see cref="ICacheHash"/> adding it to the service collection
+        /// </summary>
+        /// <typeparam name="TCacheHash">The type of class implementing <see cref="ICacheHash"/>to add.</typeparam>
+        /// <param name="builder">The <see cref="IImageSharpCoreBuilder"/></param>
+        /// <param name="implementationFactory">The factory method for returning a <see cref="ICacheHash"/>"/></param>
+        /// <returns>The <see cref="IImageSharpCoreBuilder"/>.</returns>
+        public static IImageSharpCoreBuilder SetCacheHash<TCacheHash>(this IImageSharpCoreBuilder builder, Func<IServiceProvider, TCacheHash> implementationFactory)
+            where TCacheHash : class, ICacheHash
+        {
+            builder.Services.AddSingleton(implementationFactory);
+            return builder;
+        }
+
+        /// <summary>
         /// Sets the given <see cref="IAsyncKeyLock"/> adding it to the service collection
         /// </summary>
         /// <typeparam name="TLock">The type of class implementing <see cref="IAsyncKeyLock"/>to add.</typeparam>

--- a/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
@@ -94,6 +94,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
 
             builder.SetCache<PhysicalFileSystemCache>();
 
+            builder.SetCacheHash<CacheHash>();
+
             builder.SetAsyncKeyLock<AsyncKeyLock>();
 
             builder.AddResolver<PhysicalFileSystemResolver>();

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -8,7 +8,7 @@ using SixLabors.ImageSharp.Formats;
 namespace SixLabors.ImageSharp.Web
 {
     /// <summary>
-    /// A class encapulating an image with a particular file encoding
+    /// A class encapsulating an image with a particular file encoding
     /// </summary>
     /// <seealso cref="System.IDisposable" />
     public class FormattedImage : IDisposable
@@ -62,7 +62,7 @@ namespace SixLabors.ImageSharp.Web
         /// <summary>
         /// Loads the specified source
         /// </summary>
-        /// <param name="configuation">The configuation.</param>
+        /// <param name="configuation">The configuration.</param>
         /// <param name="source">The source.</param>
         /// <returns>A formatted image</returns>
         public static FormattedImage Load(Configuration configuation, byte[] source)

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.Http;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Resolvers;
@@ -18,17 +17,22 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <summary>
         /// Gets or sets the base library configuration
         /// </summary>
-        public Configuration Configuration { get; set; }
+        public Configuration Configuration { get; set; } = Configuration.Default;
 
         /// <summary>
         /// Gets or sets the number of days to store images in the browser cache.
         /// </summary>
-        public int MaxBrowserCacheDays { get; set; }
+        public int MaxBrowserCacheDays { get; set; } = 7;
 
         /// <summary>
         /// Gets or sets the number of days to store images in the image cache.
         /// </summary>
-        public int MaxCacheDays { get; set; }
+        public int MaxCacheDays { get; set; } = 365;
+
+        /// <summary>
+        /// Gets or sets the length of the filename to use (minus the extension) when storing images in the image cache.
+        /// </summary>
+        public uint CachedNameLength { get; set; } = 12;
 
         /// <summary>
         /// Gets or sets the additional validation method.

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/tests/ImageSharp.Web.Tests/Caching/CacheHashTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/CacheHashTests.cs
@@ -4,24 +4,28 @@
 using System.IO;
 using Xunit;
 using SixLabors.ImageSharp.Web.Caching;
+using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp.Web.Middleware;
 
 namespace SixLabors.ImageSharp.Web.Tests.Caching
 {
     public class CacheHashTests
     {
+        private static readonly ICacheHash cacheHash = new CacheHash(Options.Create(new ImageSharpMiddlewareOptions()));
+
         [Fact]
         public void CacheHashEncodesExtensionCorrectly()
         {
             // Expected extension should match the default extension of the installed format
             string input = "http://testwebsite.com/image-12345.jpeg?width=400";
             string expected = ".jpeg";
-            string actual = CacheHash.Create(input, Configuration.Default);
+            string actual = cacheHash.Create(input, 8);
 
             Assert.Equal(expected, Path.GetExtension(actual));
 
             string input2 = "http://testwebsite.com/image-12345.jpeg?width=400&format=png";
             string expected2 = ".png";
-            string actual2 = CacheHash.Create(input2, Configuration.Default);
+            string actual2 = cacheHash.Create(input2, 8);
 
             Assert.Equal(expected2, Path.GetExtension(actual2));
         }
@@ -30,8 +34,8 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
         public void CachHashProducesIdenticalResults()
         {
             string input = "http://testwebsite.com/image-12345.jpeg?width=400";
-            string expected = CacheHash.Create(input, Configuration.Default);
-            string actual = CacheHash.Create(input, Configuration.Default);
+            string expected = cacheHash.Create(input, 8);
+            string actual = cacheHash.Create(input, 8);
 
             Assert.Equal(expected, actual);
         }
@@ -41,10 +45,11 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
         {
             string input = "http://testwebsite.com/image-12345.jpeg?width=400";
             string input2 = "http://testwebsite.com/image-12345.jpeg";
-            int expected = CacheHash.Create(input, Configuration.Default).Length;
-            int actual = CacheHash.Create(input2, Configuration.Default).Length;
+            int expected = cacheHash.Create(input, 12).Length;
+            int actual = cacheHash.Create(input2, 12).Length;
 
             Assert.Equal(expected, actual);
+            Assert.Equal(17, actual);
         }
     }
 }

--- a/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
+++ b/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
@@ -35,6 +35,7 @@ namespace SixLabors.ImageSharp.Web.Tests
                             options.Configuration = Configuration.Default;
                             options.MaxBrowserCacheDays = -1;
                             options.MaxCacheDays = -1;
+                            options.CachedNameLength = 12;
                             options.OnValidate = _ => { };
                             options.OnBeforeSave = _ => { };
                             options.OnProcessed = _ => { };
@@ -42,6 +43,7 @@ namespace SixLabors.ImageSharp.Web.Tests
                         })
                     .SetUriParser<QueryCollectionUriParser>()
                     .SetCache<PhysicalFileSystemCache>()
+                    .SetCacheHash<CacheHash>()
                     .SetAsyncKeyLock<AsyncKeyLock>()
                     .AddResolver<PhysicalFileSystemResolver>()
                     .AddProcessor<ResizeWebProcessor>();
@@ -68,6 +70,7 @@ namespace SixLabors.ImageSharp.Web.Tests
                 })
                 .SetUriParser<QueryCollectionUriParser>()
                 .SetCache<PhysicalFileSystemCache>()
+                .SetCacheHash<CacheHash>()
                 .SetAsyncKeyLock<AsyncKeyLock>()
                 .AddResolver<PhysicalFileSystemResolver>()
                 .AddProcessor<ResizeWebProcessor>();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR does several things
- Fixes #15 by adding a specific error message
- Adds `ICacheHash` and default implementation that allows users to generate their own file name hashing algorithm. 
- Replaced current hashing with simpler SHA256 implementation (this breaks current caches but speeds up hashing)
- Add `CachedNameLength` to our options. When using the default cache this allows increased nesting and reduction of collision probability.

<!-- Thanks for contributing to ImageSharp! -->
