### PR TITLE
Slightly more efficient hashing + Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - os: linux # Ubuntu 14.04
       dist: trusty
       sudo: required
-      dotnet: 2.0.0
+      dotnet: 2.1.4
       mono: latest
 #    - os: osx # OSX 10.11
 #      osx_image: xcode7.3.1

--- a/ImageSharp.Web.sln
+++ b/ImageSharp.Web.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{EA41
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageSharp.Web.Sample", "samples\ImageSharp.Web.Sample\ImageSharp.Web.Sample.csproj", "{BD73DBBD-6859-44C2-99FC-84148A6239A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageSharp.Web.Benchmarks", "tests\ImageSharp.Web.Benchmarks\ImageSharp.Web.Benchmarks.csproj", "{0B15E490-7821-42DF-86A5-4DEAE921DE59}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,18 @@ Global
 		{BD73DBBD-6859-44C2-99FC-84148A6239A5}.Release|x64.Build.0 = Release|Any CPU
 		{BD73DBBD-6859-44C2-99FC-84148A6239A5}.Release|x86.ActiveCfg = Release|Any CPU
 		{BD73DBBD-6859-44C2-99FC-84148A6239A5}.Release|x86.Build.0 = Release|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Debug|x64.Build.0 = Debug|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Debug|x86.Build.0 = Debug|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Release|x64.ActiveCfg = Release|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Release|x64.Build.0 = Release|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Release|x86.ActiveCfg = Release|Any CPU
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -89,6 +103,7 @@ Global
 		{2F1B36E2-5D92-4442-B816-D2A978246435} = {815C0625-CD3D-440F-9F80-2D83856AB7AE}
 		{8864C96C-94AA-454D-BAF5-779216C3745A} = {56801022-D71A-4FBE-BC5B-CBA08E2284EC}
 		{BD73DBBD-6859-44C2-99FC-84148A6239A5} = {EA4178FC-11E3-496A-B630-0680B35E0AF8}
+		{0B15E490-7821-42DF-86A5-4DEAE921DE59} = {56801022-D71A-4FBE-BC5B-CBA08E2284EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5B38B65-A19E-4359-859C-5B2205429BD1}

--- a/src/ImageSharp.Web/Commands/TypeConstants.cs
+++ b/src/ImageSharp.Web/Commands/TypeConstants.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Web.Commands
 {
@@ -67,7 +67,7 @@ namespace SixLabors.ImageSharp.Web.Commands
         };
 
         /// <summary>
-        /// The <see cref="global::SixLabors.ImageSharp.Rgba32"/> type
+        /// The <see cref="PixelFormats.Rgba32"/> type
         /// </summary>
         public static readonly Type Rgba32 = typeof(Rgba32);
     }

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Web
 {

--- a/src/ImageSharp.Web/Helpers/FormatHelpers.cs
+++ b/src/ImageSharp.Web/Helpers/FormatHelpers.cs
@@ -17,7 +17,7 @@ namespace SixLabors.ImageSharp.Web.Helpers
     public class FormatHelpers
     {
         /// <summary>
-        /// Returns the correct content type (mimetype) for the given cached image key.
+        /// Returns the correct content type (mime-type) for the given cached image key.
         /// </summary>
         /// <param name="configuration">The library configuration</param>
         /// <param name="key">The cache key</param>
@@ -52,7 +52,7 @@ namespace SixLabors.ImageSharp.Web.Helpers
             {
                 foreach (string ext in format.FileExtensions)
                 {
-                    int i = path.LastIndexOf("." + ext, StringComparison.OrdinalIgnoreCase);
+                    int i = path.LastIndexOf($".{ext}", StringComparison.OrdinalIgnoreCase);
                     if (i < index)
                     {
                         continue;

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0002" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-dev000924" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-dev000924" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0003" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -5,6 +5,7 @@
     <VersionPrefix>1.0.0-alpha9</VersionPrefix>
     <Authors>James Jackson-South and contributors</Authors>
     <TargetFrameworks>netstandard1.4;netstandard2.0</TargetFrameworks>
+    <LangVersion>7.2</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SixLabors.ImageSharp.Web</AssemblyName>

--- a/src/ImageSharp.Web/Processors/BackgroundColorWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/BackgroundColorWebProcessor.cs
@@ -3,7 +3,9 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Overlays;
 using SixLabors.ImageSharp.Web.Commands;
 
 namespace SixLabors.ImageSharp.Web.Processors

--- a/src/ImageSharp.Web/Processors/FormatWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/FormatWebProcessor.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Middleware;
@@ -52,7 +50,7 @@ namespace SixLabors.ImageSharp.Web.Processors
 
             if (!string.IsNullOrWhiteSpace(extension))
             {
-                IImageFormat format = this.options.Configuration.FindFormatByFileExtension(extension);
+                IImageFormat format = this.options.Configuration.ImageFormatsManager.FindFormatByFileExtension(extension);
 
                 if (format != null)
                 {

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -3,8 +3,9 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Processing.Transforms;
+using SixLabors.ImageSharp.Processing.Transforms.Resamplers;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.Primitives;
 
@@ -103,11 +104,7 @@ namespace SixLabors.ImageSharp.Web.Processors
             };
 
             // Defaults to Bicubic if not set.
-            IResampler sampler = GetSampler(commands);
-            if (sampler != null)
-            {
-                options.Sampler = sampler;
-            }
+            options.Sampler = GetSampler(commands);
 
             return options;
         }
@@ -131,9 +128,9 @@ namespace SixLabors.ImageSharp.Web.Processors
             return parser.ParseValue<ResizeMode>(commands.GetValueOrDefault(Mode));
         }
 
-        private static AnchorPosition GetAnchor(IDictionary<string, string> commands, CommandParser parser)
+        private static AnchorPositionMode GetAnchor(IDictionary<string, string> commands, CommandParser parser)
         {
-            return parser.ParseValue<AnchorPosition>(commands.GetValueOrDefault(Anchor));
+            return parser.ParseValue<AnchorPositionMode>(commands.GetValueOrDefault(Anchor));
         }
 
         private static bool GetCompandMode(IDictionary<string, string> commands, CommandParser parser)
@@ -149,21 +146,24 @@ namespace SixLabors.ImageSharp.Web.Processors
             {
                 switch (sampler.ToLowerInvariant())
                 {
-                    case "nearest": return new NearestNeighborResampler();
-                    case "box": return new BoxResampler();
-                    case "mitchell": return new MitchellNetravaliResampler();
-                    case "catmull": return new CatmullRomResampler();
-                    case "lanczos2": return new Lanczos2Resampler();
-                    case "lanczos3": return new Lanczos3Resampler();
-                    case "lanczos5": return new Lanczos5Resampler();
-                    case "lanczos8": return new Lanczos8Resampler();
-                    case "welch": return new WelchResampler();
-                    case "triangle": return new TriangleResampler();
-                    case "hermite": return new HermiteResampler();
+                    case "nearest": return KnownResamplers.NearestNeighbor;
+                    case "box": return KnownResamplers.Box;
+                    case "mitchell": return KnownResamplers.MitchellNetravali;
+                    case "catmull": return KnownResamplers.CatmullRom;
+                    case "lanczos2": return KnownResamplers.Lanczos2;
+                    case "lanczos3": return KnownResamplers.Lanczos3;
+                    case "lanczos5": return KnownResamplers.Lanczos5;
+                    case "lanczos8": return KnownResamplers.Lanczos8;
+                    case "welch": return KnownResamplers.Welch;
+                    case "robidoux": return KnownResamplers.Robidoux;
+                    case "robidouxsharp": return KnownResamplers.RobidouxSharp;
+                    case "spline": return KnownResamplers.Spline;
+                    case "triangle": return KnownResamplers.Triangle;
+                    case "hermite": return KnownResamplers.Hermite;
                 }
             }
 
-            return null;
+            return KnownResamplers.Bicubic;
         }
     }
 }

--- a/tests/ImageSharp.Web.Benchmarks/Caching/CacheHashBenchmarks.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Caching/CacheHashBenchmarks.cs
@@ -1,0 +1,27 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp.Web.Caching;
+using SixLabors.ImageSharp.Web.Middleware;
+
+namespace ImageSharp.Web.Benchmarks.Caching
+{
+    [Config(typeof(MemoryConfig))]
+    public class CacheHashBenchmarks
+    {
+        private const string URL = "http://testwebsite.com/image-12345.jpeg?width=400";
+        private static CacheHash Sha256Hasher = new CacheHash(Options.Create(new ImageSharpMiddlewareOptions()));
+        private static CacheHashBaseline NaiveSha256Hasher = new CacheHashBaseline(Options.Create(new ImageSharpMiddlewareOptions()));
+
+        [Benchmark(Baseline = true, Description = "Baseline Sha256Hasher")]
+        public string HashUsingXxHash()
+        {
+            return NaiveSha256Hasher.Create(URL, 12);
+        }
+
+        [Benchmark(Description = "Sha256Hasher")]
+        public string HashUsingSha256()
+        {
+            return Sha256Hasher.Create(URL, 12);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Benchmarks/ImageSharp.Web.Benchmarks.csproj
+++ b/tests/ImageSharp.Web.Benchmarks/ImageSharp.Web.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ImageSharp.Web\ImageSharp.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ImageSharp.Web.Benchmarks/MemoryConfig.cs
+++ b/tests/ImageSharp.Web.Benchmarks/MemoryConfig.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Configs;
+
+namespace ImageSharp.Web.Benchmarks
+{
+    public class MemoryConfig : ManualConfig
+    {
+        public MemoryConfig()
+        {
+            this.Add(new BenchmarkDotNet.Diagnosers.MemoryDiagnoser());
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Benchmarks/Program.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using BenchmarkDotNet.Running;
+
+namespace ImageSharp.Web.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            new BenchmarkSwitcher(typeof(Program).GetTypeInfo().Assembly).Run(args);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Commands/CommandParserTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/CommandParserTests.cs
@@ -4,7 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing.Transforms;
 using SixLabors.ImageSharp.Web.Commands;
 using Xunit;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Reduces the allocation per hash generation from 2.48kb to 2.4kb.
Possible to reduce slightly further using .NET Core 2.1

<!-- Thanks for contributing to ImageSharp! -->
