### PR TITLE
ICacheHash parameter null check fixed

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -112,7 +112,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
             Guard.NotNull(resolvers, nameof(resolvers));
             Guard.NotNull(processors, nameof(processors));
             Guard.NotNull(cache, nameof(cache));
-            Guard.NotNull(cache, nameof(cacheHash));
+            Guard.NotNull(cacheHash, nameof(cacheHash));
             Guard.NotNull(AsyncLock, nameof(AsyncLock));
 
             this.next = next;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
ICacheHash parameter null check fixed on ImageSharpMiddleware constructor.
