### PR TITLE
Replace IImageProvider.Get() with GetAsync()

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -170,7 +170,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
             bool processRequest = true;
             var imageContext = new ImageContext(context, this.options);
-            IImageResolver resolvedImage = provider.Get(context);
+            IImageResolver resolvedImage = await provider.GetAsync(context).ConfigureAwait(false);
 
             if (resolvedImage == null)
             {

--- a/src/ImageSharp.Web/Providers/IImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/IImageProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using SixLabors.ImageSharp.Web.Resolvers;
 
@@ -37,6 +38,6 @@ namespace SixLabors.ImageSharp.Web.Providers
         /// </summary>
         /// <param name="context">The current HTTP request context.</param>
         /// <returns>The <see cref="IImageResolver"/>.</returns>
-        IImageResolver Get(HttpContext context);
+        Task<IImageResolver> GetAsync(HttpContext context);
     }
 }

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -68,7 +69,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         public bool IsValidRequest(HttpContext context) => this.formatHelper.GetExtension(context.Request.GetDisplayUrl()) != null;
 
         /// <inheritdoc/>
-        public IImageResolver Get(HttpContext context)
+        public Task<IImageResolver> GetAsync(HttpContext context)
         {
             // Path has already been correctly parsed before here.
             IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path.Value);
@@ -76,10 +77,10 @@ namespace SixLabors.ImageSharp.Web.Providers
             // Check to see if the file exists.
             if (!fileInfo.Exists)
             {
-                return null;
+                return Task.FromResult<IImageResolver>(null);
             }
 
-            return new PhysicalFileSystemResolver(fileInfo);
+            return Task.FromResult<IImageResolver>(new PhysicalFileSystemResolver(fileInfo));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
This makes it possible for implementations of IImageProvider that rely on remote image sources to asynchronously create an IImageResolver.  This is important as it allows them to determine whether the requested image exists or not in an asynchronous manner prior to returning the IImageResolver.