### PR TITLE
WIP: Add image cache metadata

### DIFF
--- a/src/ImageSharp.Web/Caching/IImageCache.cs
+++ b/src/ImageSharp.Web/Caching/IImageCache.cs
@@ -26,7 +26,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// </summary>
         /// <param name="key">The cache key.</param>
         /// <returns>The <see cref="IImageResolver"/>.</returns>
-        IImageResolver Get(string key);
+        Task<IImageResolver> GetAsync(string key);
 
         /// <summary>
         /// Returns a value indicating whether the current cached item is expired.
@@ -47,7 +47,8 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// </summary>
         /// <param name="key">The cache key.</param>
         /// <param name="stream">The stream containing the image to store.</param>
+        /// <param name="contentType">The content type of the image to store.</param>
         /// <returns>The <see cref="Task{DateTimeOffset}"/>.</returns>
-        Task<DateTimeOffset> SetAsync(string key, Stream stream);
+        Task<DateTimeOffset> SetAsync(string key, Stream stream, string contentType);
     }
 }

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -80,7 +80,10 @@ namespace SixLabors.ImageSharp.Web.Providers
                 return Task.FromResult<IImageResolver>(null);
             }
 
-            return Task.FromResult<IImageResolver>(new PhysicalFileSystemResolver(fileInfo));
+            // Make an educated guess of the contentType based on the filename.
+            string contentType = this.formatHelper.GetContentType(fileInfo.Name);
+
+            return Task.FromResult<IImageResolver>(new PhysicalFileSystemResolver(fileInfo, contentType));
         }
     }
 }

--- a/src/ImageSharp.Web/Resolvers/IImageResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/IImageResolver.cs
@@ -19,6 +19,12 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         Task<DateTime> GetLastWriteTimeUtcAsync();
 
         /// <summary>
+        /// Gets the content type of the image data.
+        /// </summary>
+        /// <returns>The content type.</returns>
+        Task<string> GetContentTypeAsync();
+
+        /// <summary>
         /// Gets the input image stream in an asynchronous manner.
         /// </summary>
         /// <returns>The <see cref="Task{Stream}"/>.</returns>

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
@@ -14,15 +14,24 @@ namespace SixLabors.ImageSharp.Web.Resolvers
     public class PhysicalFileSystemResolver : IImageResolver
     {
         private readonly IFileInfo fileInfo;
+        private readonly string contentType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalFileSystemResolver"/> class.
         /// </summary>
         /// <param name="fileInfo">The input file info.</param>
-        public PhysicalFileSystemResolver(IFileInfo fileInfo) => this.fileInfo = fileInfo;
+        /// <param name="contentType">The content type of this file.</param>
+        public PhysicalFileSystemResolver(IFileInfo fileInfo, string contentType)
+        {
+            this.fileInfo = fileInfo;
+            this.contentType = contentType;
+        }
 
         /// <inheritdoc/>
         public Task<DateTime> GetLastWriteTimeUtcAsync() => Task.FromResult(this.fileInfo.LastModified.UtcDateTime);
+
+        /// <inheritdoc/>
+        public Task<string> GetContentTypeAsync() => Task.FromResult(this.contentType);
 
         /// <inheritdoc/>
         public Task<Stream> OpenReadAsync() => Task.FromResult(this.fileInfo.CreateReadStream());


### PR DESCRIPTION
_This is still a work-in-progress.  I'm creating a PR now so we can discuss the design and make sure this is a reasonable direction to pursue._

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This adds a mechanism to store additional metadata alongside cached images.  The first use of this metadata cache is to store the Content-Type of the image so that we don't have to rely on making assumptions based on the filename, but can instead use the _actual_ image format information obtained when originally processing the image.