### PR TITLE
Fix race-condition in AsyncKeyLock

### DIFF
--- a/src/ImageSharp.Web/Caching/AsyncKeyLock.cs
+++ b/src/ImageSharp.Web/Caching/AsyncKeyLock.cs
@@ -33,7 +33,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <summary>
         /// SpinLock used to protect access to the Keys and Pool collections.
         /// </summary>
-        private static SpinLock Lock = new SpinLock(false);
+        private static SpinLock spinLock = new SpinLock(false);
 
         /// <summary>
         /// Locks the current thread in read mode asynchronously.
@@ -76,7 +76,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             bool lockTaken = false;
             try
             {
-                Lock.Enter(ref lockTaken);
+                spinLock.Enter(ref lockTaken);
 
                 if (!Keys.TryGetValue(key, out doorman))
                 {
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             {
                 if (lockTaken)
                 {
-                    Lock.Exit();
+                    spinLock.Exit();
                 }
             }
 
@@ -109,7 +109,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             bool lockTaken = false;
             try
             {
-                Lock.Enter(ref lockTaken);
+                spinLock.Enter(ref lockTaken);
 
                 if (--doorman.RefCount == 0)
                 {
@@ -125,7 +125,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             {
                 if (lockTaken)
                 {
-                    Lock.Exit();
+                    spinLock.Exit();
                 }
             }
         }

--- a/src/ImageSharp.Web/Caching/Doorman.cs
+++ b/src/ImageSharp.Web/Caching/Doorman.cs
@@ -15,8 +15,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         private readonly Queue<TaskCompletionSource<Releaser>> waitingWriters;
         private readonly Task<Releaser> readerReleaser;
         private readonly Task<Releaser> writerReleaser;
-        private readonly string key;
-        private readonly Action reset;
+        private readonly Action<Doorman> reset;
         private TaskCompletionSource<Releaser> waitingReader;
         private int readersWaiting;
         private int status;
@@ -26,17 +25,27 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// </summary>
         /// <param name="key">The key to identify the doorman instance.</param>
         /// <param name="reset">The reset action.</param>
-        public Doorman(string key, Action reset)
+        public Doorman(string key, Action<Doorman> reset)
         {
             this.waitingWriters = new Queue<TaskCompletionSource<Releaser>>();
             this.waitingReader = new TaskCompletionSource<Releaser>();
             this.status = 0;
 
-            this.key = key;
+            this.Key = key;
             this.readerReleaser = Task.FromResult(new Releaser(this, false));
             this.writerReleaser = Task.FromResult(new Releaser(this, true));
             this.reset = reset;
         }
+
+        /// <summary>
+        /// Gets the key that this doorman is mapped to.
+        /// </summary>
+        public string Key { get; }
+
+        /// <summary>
+        /// Gets or sets the current reference count on this doorman.
+        /// </summary>
+        public int RefCount { get; set; }
 
         /// <summary>
         /// Locks the current thread in read mode asynchronously.
@@ -96,12 +105,10 @@ namespace SixLabors.ImageSharp.Web.Caching
                         this.status = -1;
                         toWake = this.waitingWriters.Dequeue();
                     }
-                    else
-                    {
-                        this.reset();
-                    }
                 }
             }
+
+            this.reset(this);
 
             toWake?.SetResult(new Releaser(this, true));
         }
@@ -127,9 +134,11 @@ namespace SixLabors.ImageSharp.Web.Caching
                 }
                 else
                 {
-                    this.reset();
+                    this.status = 0;
                 }
             }
+
+            this.reset(this);
 
             toWake?.SetResult(new Releaser(this, toWakeIsWriter));
         }

--- a/src/ImageSharp.Web/Caching/Doorman.cs
+++ b/src/ImageSharp.Web/Caching/Doorman.cs
@@ -23,24 +23,22 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <summary>
         /// Initializes a new instance of the <see cref="Doorman"/> class.
         /// </summary>
-        /// <param name="key">The key to identify the doorman instance.</param>
         /// <param name="reset">The reset action.</param>
-        public Doorman(string key, Action<Doorman> reset)
+        public Doorman(Action<Doorman> reset)
         {
             this.waitingWriters = new Queue<TaskCompletionSource<Releaser>>();
             this.waitingReader = new TaskCompletionSource<Releaser>();
             this.status = 0;
 
-            this.Key = key;
             this.readerReleaser = Task.FromResult(new Releaser(this, false));
             this.writerReleaser = Task.FromResult(new Releaser(this, true));
             this.reset = reset;
         }
 
         /// <summary>
-        /// Gets the key that this doorman is mapped to.
+        /// Gets or sets the key that this doorman is mapped to.
         /// </summary>
-        public string Key { get; }
+        public string Key { get; set; }
 
         /// <summary>
         /// Gets or sets the current reference count on this doorman.


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
This change addresses the race conditions identified in #56 by adding a RefCount property to the Doorman class and then using a SpinLock to serialize access to the Keys dictionary.  It also adds a pool so that unused doormen can be re-used in order to cut down on GC allocations and reduce the time spent holding the SpinLock.