### PR TITLE
Fix metadata read datetime to UTC

### DIFF
--- a/src/ImageSharp.Web/ImageMetadata.cs
+++ b/src/ImageSharp.Web/ImageMetadata.cs
@@ -113,7 +113,7 @@ namespace SixLabors.ImageSharp.Web
 
             // DateTime.TryParse(null) ==  DateTime.MinValue so no need for conditional;
             keyValuePairs.TryGetValue(LastModifiedKey, out string lastWriteTimeUtcString);
-            DateTime.TryParse(lastWriteTimeUtcString, out DateTime lastWriteTimeUtc);
+            DateTime.TryParse(lastWriteTimeUtcString, null, DateTimeStyles.RoundtripKind, out DateTime lastWriteTimeUtc);
 
             keyValuePairs.TryGetValue(ContentTypeKey, out string contentType);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Read metadata is returning date in local time. When parsing "o" format specifier, the formatted string should be parsed with `DateTimeStyles.RoundtripKind`. More info [here](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#the-round-trip-o-o-format-specifier)

<!-- Thanks for contributing to ImageSharp! -->
