### PR TITLE
Improve ImageSharpMiddleware no-op case's performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,7 @@ artifacts/
 docs/
 
 **/is-cache/
+
+# Rider
+.idea
+

--- a/src/ImageSharp.Web/Commands/QueryCollectionRequestParser.cs
+++ b/src/ImageSharp.Web/Commands/QueryCollectionRequestParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 
 namespace SixLabors.ImageSharp.Web.Commands
 {
@@ -21,7 +22,7 @@ namespace SixLabors.ImageSharp.Web.Commands
                 return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
-            var parsed = QueryHelpers.ParseQuery(context.Request.QueryString.ToUriComponent());
+            Dictionary<string, StringValues> parsed = QueryHelpers.ParseQuery(context.Request.QueryString.ToUriComponent());
             var transformed = new Dictionary<string, string>(parsed.Count);
             foreach (var pair in parsed)
             {

--- a/src/ImageSharp.Web/Commands/QueryCollectionRequestParser.cs
+++ b/src/ImageSharp.Web/Commands/QueryCollectionRequestParser.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 
@@ -12,18 +11,24 @@ namespace SixLabors.ImageSharp.Web.Commands
     /// <summary>
     /// Parses commands from the request querystring.
     /// </summary>
-    public class QueryCollectionRequestParser : IRequestParser
+    public sealed class QueryCollectionRequestParser : IRequestParser
     {
         /// <inheritdoc/>
         public IDictionary<string, string> ParseRequestCommands(HttpContext context)
         {
-            if (!context.Request.Query.Any())
+            if (context.Request.Query.Count == 0)
             {
                 return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
-            return QueryHelpers.ParseQuery(context.Request.QueryString.ToUriComponent())
-                               .ToDictionary(k => k.Key, v => v.Value.ToString());
+            var parsed = QueryHelpers.ParseQuery(context.Request.QueryString.ToUriComponent());
+            var transformed = new Dictionary<string, string>(parsed.Count);
+            foreach (var pair in parsed)
+            {
+                transformed[pair.Key] = pair.Value.ToString();
+            }
+
+            return transformed;
         }
     }
 }

--- a/src/ImageSharp.Web/Guard.cs
+++ b/src/ImageSharp.Web/Guard.cs
@@ -30,13 +30,12 @@ namespace SixLabors.ImageSharp.Web
         {
             if (target == null)
             {
-                ThrowArgumentNull<T>(parameterName, message);
+                ThrowArgumentNull(parameterName, message);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowArgumentNull<T>(string parameterName, string message)
-            where T : class
+        private static void ThrowArgumentNull(string parameterName, string message)
         {
             if (!string.IsNullOrWhiteSpace(message))
             {

--- a/src/ImageSharp.Web/Guard.cs
+++ b/src/ImageSharp.Web/Guard.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp.Web
 {
@@ -23,18 +24,26 @@ namespace SixLabors.ImageSharp.Web
         /// <param name="parameterName">The name of the parameter that is to be checked.</param>
         /// <param name="message">The error message, if any to add to the exception.</param>
         /// <exception cref="ArgumentNullException"><paramref name="target"/> is null.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void NotNull<T>(T target, string parameterName, string message = "")
             where T : class
         {
             if (target == null)
             {
-                if (!string.IsNullOrWhiteSpace(message))
-                {
-                    throw new ArgumentNullException(parameterName, message);
-                }
-
-                throw new ArgumentNullException(parameterName);
+                ThrowArgumentNull<T>(parameterName, message);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowArgumentNull<T>(string parameterName, string message)
+            where T : class
+        {
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentNullException(parameterName, message);
+            }
+
+            throw new ArgumentNullException(parameterName);
         }
 
         /// <summary>
@@ -47,19 +56,26 @@ namespace SixLabors.ImageSharp.Web
         /// <param name="message">The error message, if any to add to the exception.</param>
         /// <exception cref="ArgumentNullException"><paramref name="target"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="target"/> is empty or contains only blanks.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void NotNullOrWhiteSpace(string target, string parameterName, string message = "")
         {
             NotNull(target, parameterName, message);
 
             if (string.IsNullOrWhiteSpace(target))
             {
-                if (!string.IsNullOrWhiteSpace(message))
-                {
-                    throw new ArgumentException(message, parameterName);
-                }
-
-                throw new ArgumentException("Value cannot be null, empty, or cannot contain only whitespace.", parameterName);
+                ThrowArgumentException(parameterName, message);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowArgumentException(string parameterName, string message)
+        {
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentException(message, parameterName);
+            }
+
+            throw new ArgumentException("Value cannot be null, empty, or cannot contain only whitespace.", parameterName);
         }
 
         /// <summary>

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -152,7 +152,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task Invoke(HttpContext context)
         {
-            var commands = this.requestParser.ParseRequestCommands(context);
+            IDictionary<string, string> commands = this.requestParser.ParseRequestCommands(context);
             if (commands.Count > 0)
             {
                 foreach (var command in commands.Keys)
@@ -199,6 +199,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
             {
                 // Call the next delegate/middleware in the pipeline
                 await this.next(context).ConfigureAwait(false);
+                return;
             }
 
             await this.ProcessRequest(context, processRequest, sourceImageResolver, new ImageContext(context, this.options), commands);

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -57,12 +58,12 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <summary>
         /// The collection of image resolvers.
         /// </summary>
-        private readonly List<IImageProvider> resolvers;
+        private readonly IImageProvider[] resolvers;
 
         /// <summary>
         /// The collection of image processors.
         /// </summary>
-        private readonly List<IImageWebProcessor> processors;
+        private readonly IImageWebProcessor[] processors;
 
         /// <summary>
         /// The image cache.
@@ -124,8 +125,8 @@ namespace SixLabors.ImageSharp.Web.Middleware
             this.options = options.Value;
             this.memoryAllocator = memoryAllocator;
             this.requestParser = requestParser;
-            this.resolvers = new List<IImageProvider>(resolvers);
-            this.processors = new List<IImageWebProcessor>(processors);
+            this.resolvers = resolvers as IImageProvider[] ?? resolvers.ToArray();
+            this.processors = processors as IImageWebProcessor[] ?? processors.ToArray();
             this.cache = cache;
             this.cacheHash = cacheHash;
 
@@ -167,15 +168,12 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
             // Get the correct service for the request.
             IImageProvider provider = null;
-            if (this.resolvers.Count > 0)
+            foreach (var resolver in this.resolvers)
             {
-                foreach (var resolver in this.resolvers)
+                if (resolver.Match(context))
                 {
-                    if (resolver.Match(context))
-                    {
-                        provider = resolver;
-                        break;
-                    }
+                    provider = resolver;
+                    break;
                 }
             }
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -58,12 +57,12 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <summary>
         /// The collection of image resolvers.
         /// </summary>
-        private readonly IEnumerable<IImageProvider> resolvers;
+        private readonly List<IImageProvider> resolvers;
 
         /// <summary>
         /// The collection of image processors.
         /// </summary>
-        private readonly IEnumerable<IImageWebProcessor> processors;
+        private readonly List<IImageWebProcessor> processors;
 
         /// <summary>
         /// The image cache.
@@ -78,7 +77,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <summary>
         /// The collection of known commands gathered from the processors.
         /// </summary>
-        private readonly IEnumerable<string> knownCommands;
+        private readonly HashSet<string> knownCommands;
 
         /// <summary>
         /// Contains various helper methods based on the current configuration.
@@ -125,15 +124,18 @@ namespace SixLabors.ImageSharp.Web.Middleware
             this.options = options.Value;
             this.memoryAllocator = memoryAllocator;
             this.requestParser = requestParser;
-            this.resolvers = resolvers;
-            this.processors = processors;
+            this.resolvers = new List<IImageProvider>(resolvers);
+            this.processors = new List<IImageWebProcessor>(processors);
             this.cache = cache;
             this.cacheHash = cacheHash;
 
-            var commands = new List<string>();
-            foreach (IImageWebProcessor processor in this.processors)
+            var commands = new HashSet<string>();
+            foreach (var processor in this.processors)
             {
-                commands.AddRange(processor.Commands);
+                foreach (var command in processor.Commands)
+                {
+                    commands.Add(command);
+                }
             }
 
             this.knownCommands = commands;
@@ -149,14 +151,33 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task Invoke(HttpContext context)
         {
-            IDictionary<string, string> commands = this.requestParser.ParseRequestCommands(context)
-                .Where(kvp => this.knownCommands.Contains(kvp.Key))
-                .ToDictionary(p => p.Key, p => p.Value);
+            var commands = this.requestParser.ParseRequestCommands(context);
+            if (commands.Count > 0)
+            {
+                foreach (var command in commands.Keys)
+                {
+                    if (!this.knownCommands.Contains(command))
+                    {
+                        commands.Remove(command);
+                    }
+                }
+            }
 
             this.options.OnParseCommands?.Invoke(new ImageCommandContext(context, commands, CommandParser.Instance));
 
             // Get the correct service for the request.
-            IImageProvider provider = this.resolvers.FirstOrDefault(r => r.Match(context));
+            IImageProvider provider = null;
+            if (this.resolvers.Count > 0)
+            {
+                foreach (var resolver in this.resolvers)
+                {
+                    if (resolver.Match(context))
+                    {
+                        provider = resolver;
+                        break;
+                    }
+                }
+            }
 
             if (provider?.IsValidRequest(context) != true)
             {
@@ -165,20 +186,31 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 return;
             }
 
-            // Create a cache key based on all the components of the requested url
-            string uri = GetUri(context, commands);
-            string key = this.cacheHash.Create(uri, this.options.CachedNameLength);
-
             bool processRequest = true;
-            var imageContext = new ImageContext(context, this.options);
             IImageResolver sourceImageResolver = await provider.GetAsync(context).ConfigureAwait(false);
 
             if (sourceImageResolver == null)
             {
                 // Log the error but let the pipeline handle the 404
+                var imageContext = new ImageContext(context, this.options);
                 this.logger.LogImageResolveFailed(imageContext.GetDisplayUrl());
                 processRequest = false;
             }
+
+            if (!processRequest)
+            {
+                // Call the next delegate/middleware in the pipeline
+                await this.next(context).ConfigureAwait(false);
+            }
+
+            await this.ProcessRequest(context, processRequest, sourceImageResolver, new ImageContext(context, this.options), commands);
+        }
+
+        private async Task ProcessRequest(HttpContext context, bool processRequest, IImageResolver sourceImageResolver, ImageContext imageContext, IDictionary<string, string> commands)
+        {
+            // Create a cache key based on all the components of the requested url
+            string uri = GetUri(context, commands);
+            string key = this.cacheHash.Create(uri, this.options.CachedNameLength);
 
             ImageMetaData sourceImageMetadata = default;
             if (processRequest)
@@ -266,12 +298,6 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 {
                     outStream?.Dispose();
                 }
-            }
-
-            if (!processRequest)
-            {
-                // Call the next delegate/middleware in the pipeline
-                await this.next(context).ConfigureAwait(false);
             }
         }
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -39,18 +39,23 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// This is called once the commands have been gathered and before an <see cref="IImageProvider"/> has been assigned.
         /// </summary>
         public Action<ImageCommandContext> OnParseCommands { get; set; } = c =>
+        {
+            if (c.Commands.Count == 0)
             {
-                // It's a good idea to have this to provide very basic security.
-                // We can safely use the static resize processor properties.
-                uint width = c.Parser.ParseValue<uint>(c.Commands.GetValueOrDefault(ResizeWebProcessor.Width));
-                uint height = c.Parser.ParseValue<uint>(c.Commands.GetValueOrDefault(ResizeWebProcessor.Height));
+                return;
+            }
 
-                if (width > 4000 && height > 4000)
-                {
-                    c.Commands.Remove(ResizeWebProcessor.Width);
-                    c.Commands.Remove(ResizeWebProcessor.Height);
-                }
-            };
+            // It's a good idea to have this to provide very basic security.
+            // We can safely use the static resize processor properties.
+            uint width = c.Parser.ParseValue<uint>(c.Commands.GetValueOrDefault(ResizeWebProcessor.Width));
+            uint height = c.Parser.ParseValue<uint>(c.Commands.GetValueOrDefault(ResizeWebProcessor.Height));
+
+            if (width > 4000 && height > 4000)
+            {
+                c.Commands.Remove(ResizeWebProcessor.Width);
+                c.Commands.Remove(ResizeWebProcessor.Height);
+            }
+        };
 
         /// <summary>
         /// Gets or sets the additional method that can be used for final manipulation before the image is saved.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

I profiled [Orchard Core](https://github.com/OrchardCMS/OrchardCore) as @sebastienros gave the idea. I saw that ImageSharp was doing some unnecessary processing as part of the pipeline when the request ended to be no-op on ImageSharp's behalf. I tweaked following bits:

* reduce usage of LINQ, which is always more expensive than "code nearer to the metal"
* change error handling to be more easy to inline (micro optimization)
* use concrete types as fields, no extra penalty from interface access
* split the actual work to `ProcessRequest` when actually needed
* don't parse in `OnParseCommands` when result is discarded

