### PR TITLE
Suggested change to logic of command processing

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -152,20 +152,6 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task Invoke(HttpContext context)
         {
-            IDictionary<string, string> commands = this.requestParser.ParseRequestCommands(context);
-            if (commands.Count > 0)
-            {
-                foreach (var command in commands.Keys)
-                {
-                    if (!this.knownCommands.Contains(command))
-                    {
-                        commands.Remove(command);
-                    }
-                }
-            }
-
-            this.options.OnParseCommands?.Invoke(new ImageCommandContext(context, commands, CommandParser.Instance));
-
             // Get the correct service for the request.
             IImageProvider provider = null;
             foreach (var resolver in this.resolvers)
@@ -201,6 +187,21 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 await this.next(context).ConfigureAwait(false);
                 return;
             }
+
+            // Process commands
+            IDictionary<string, string> commands = this.requestParser.ParseRequestCommands(context);
+            if (commands.Count > 0)
+            {
+                foreach (var command in commands.Keys)
+                {
+                    if (!this.knownCommands.Contains(command))
+                    {
+                        commands.Remove(command);
+                    }
+                }
+            }
+
+            this.options.OnParseCommands?.Invoke(new ImageCommandContext(context, commands, CommandParser.Instance));
 
             await this.ProcessRequest(context, processRequest, sourceImageResolver, new ImageContext(context, this.options), commands);
         }

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
         /// <summary>
         /// Gets or sets the additional command parsing method that can be used to used to augment commands.
-        /// This is called once the commands have been gathered and before an <see cref="IImageProvider"/> has been assigned.
+        /// This is called once the commands have been gathered and before the request is processed.
         /// </summary>
         public Action<ImageCommandContext> OnParseCommands { get; set; } = c =>
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

This is a suggested change to the logic of when commands are parsed, to further improve the no-op performance.

ImageSharp no-op's based on the result from an `IImageProvider`, which is only passed the `HttpContext` not the commands that have been processed by the request parser.

The `commands` are not used until the images are processed, as far as I can tell, unless I'm missing something?

I don't think the `OnParseCommands` Action can be used to affect the validation of a request - that functionality is with the `IImageProvider`.

With this change to the logic, `OnParseCommands` can still perform mutations to the commands, before processing.