### PR TITLE
Update remove extensions to handle implementation factories

### DIFF
--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpCoreBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpCoreBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -168,7 +169,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
             ServiceDescriptor descriptor = builder.Services.FirstOrDefault(x =>
                 x.ServiceType == typeof(IImageProvider)
                 && x.Lifetime == ServiceLifetime.Singleton
-                && x.ImplementationType == typeof(TProvider));
+                && (x.ImplementationType == typeof(TProvider)
+                || (x.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(TProvider))));
 
             if (descriptor != null)
             {
@@ -217,7 +219,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
             ServiceDescriptor descriptor = builder.Services.FirstOrDefault(x =>
                 x.ServiceType == typeof(IImageWebProcessor)
                 && x.Lifetime == ServiceLifetime.Singleton
-                && x.ImplementationType == typeof(TProcessor));
+                && (x.ImplementationType == typeof(TProcessor)
+                || (x.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(TProcessor))));
 
             if (descriptor != null)
             {

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -29,6 +29,26 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
         }
 
         [Fact]
+        public void CanAddRemoveFactoryImageProviders()
+        {
+            void RemoveServices(IServiceCollection services)
+            {
+                var builder = services.AddImageSharp()
+                                      .AddProvider(sp => new MockImageProvider());
+
+                Assert.Contains(services, x => x.ImplementationFactory?.Method.ReturnType == typeof(MockImageProvider));
+
+                builder.RemoveProvider<MockImageProvider>();
+
+                Assert.DoesNotContain(services, x => x.ImplementationFactory?.Method.ReturnType == typeof(MockImageProvider));
+            }
+
+            using (TestServer server = ImageSharpTestServer.Create(ImageSharpTestServer.DefaultConfig, RemoveServices))
+            {
+            }
+        }
+
+        [Fact]
         public void CanAddRemoveImageProcessors()
         {
             void RemoveServices(IServiceCollection services)
@@ -41,6 +61,26 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
                 builder.RemoveProcessor<MockWebProcessor>();
 
                 Assert.DoesNotContain(services, x => x.ImplementationType == typeof(MockWebProcessor));
+            }
+
+            using (TestServer server = ImageSharpTestServer.Create(ImageSharpTestServer.DefaultConfig, RemoveServices))
+            {
+            }
+        }
+
+        [Fact]
+        public void CanAddRemoveFactoryImageProcessors()
+        {
+            void RemoveServices(IServiceCollection services)
+            {
+                var builder = services.AddImageSharp()
+                                      .AddProcessor(sp => new MockWebProcessor());
+
+                Assert.Contains(services, x => x.ImplementationFactory?.Method.ReturnType == typeof(MockWebProcessor));
+
+                builder.RemoveProcessor<MockWebProcessor>();
+
+                Assert.DoesNotContain(services, x => x.ImplementationFactory?.Method.ReturnType == typeof(MockWebProcessor));
             }
 
             using (TestServer server = ImageSharpTestServer.Create(ImageSharpTestServer.DefaultConfig, RemoveServices))

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -36,6 +36,8 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
                 var builder = services.AddImageSharp()
                                       .AddProvider(sp => new MockImageProvider());
 
+                Assert.DoesNotContain(services, x => x.ImplementationType == typeof(MockImageProvider));
+
                 Assert.Contains(services, x => x.ImplementationFactory?.Method.ReturnType == typeof(MockImageProvider));
 
                 builder.RemoveProvider<MockImageProvider>();
@@ -75,6 +77,8 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
             {
                 var builder = services.AddImageSharp()
                                       .AddProcessor(sp => new MockWebProcessor());
+
+                Assert.DoesNotContain(services, x => x.ImplementationType == typeof(MockWebProcessor));
 
                 Assert.Contains(services, x => x.ImplementationFactory?.Method.ReturnType == typeof(MockWebProcessor));
 


### PR DESCRIPTION
# Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Following on from https://github.com/SixLabors/ImageSharp.Web/issues/62 this updates the `ImageSharpCoreBuilderExtensions` to also support removing registrations, when the registration occurred via a service factory.

I included a couple of new tests for implementation factory registration and removal