### PR TITLE
Return on no commands

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -166,6 +166,13 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
             this.options.OnParseCommands?.Invoke(new ImageCommandContext(context, commands, CommandParser.Instance));
 
+            if (commands.Count == 0)
+            {
+                // Nothing to do. call the next delegate/middleware in the pipeline
+                await this.next(context).ConfigureAwait(false);
+                return;
+            }
+
             // Get the correct service for the request.
             IImageProvider provider = null;
             foreach (var resolver in this.resolvers)
@@ -202,7 +209,8 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 return;
             }
 
-            await this.ProcessRequest(context, processRequest, sourceImageResolver, new ImageContext(context, this.options), commands);
+            await this.ProcessRequest(context, processRequest, sourceImageResolver, new ImageContext(context, this.options), commands)
+                      .ConfigureAwait(false);
         }
 
         private async Task ProcessRequest(HttpContext context, bool processRequest, IImageResolver sourceImageResolver, ImageContext imageContext, IDictionary<string, string> commands)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
Ensures that we return early when there are no commands to process.

<!-- Thanks for contributing to ImageSharp! -->
