### PR TITLE
added forward slash to path as it's being passed to PathString constructor which expects the path to start with /

### DIFF
--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -143,6 +143,6 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <param name="key">The cache key.</param>
         /// <returns>The <see cref="string"/>.</returns>
         private string ToFilePath(string key) // TODO: Avoid the allocation here.
-            => $"{this.cacheOptions.CacheFolder}/{string.Join("/", key.Substring(0, (int)this.options.CachedNameLength).ToCharArray())}/{key}";
+            => $"/{this.cacheOptions.CacheFolder}/{string.Join("/", key.Substring(0, (int)this.options.CachedNameLength).ToCharArray())}/{key}";
     }
 }


### PR DESCRIPTION
addresses issue #78. seems to be asp.net core 3.0 related, hopefully adding the slash doesn't break earlier releases of asp.net core.

### Prerequisites

- [x ] I have written a descriptive pull-request title
- [x ] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
