### PR TITLE
Create PhysicalFileProvider from Webroot

### DIFF
--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -58,6 +59,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description

Fixes https://github.com/SixLabors/ImageSharp.Web/issues/78

I've updated `PhysicalFileSystemCache` to create a `PhysicalFileProvider` from the `IHostingEnvironment.WebRootPath` to work around the issues some people are experiencing in development mode with core 3

It has meant taking a reference on `Microsoft.Extensions.FileProviders.Physical` but I think I've got the correct versions for both targets `netstandard1.4` and `netstandard2.0`, noting there is no released version of 1.1.2 which would match the other `netstandard1.4` targets
