### PR TITLE
Allow use of any container in AzureBlobStorageImageProvider

### DIFF
--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using Microsoft.Azure.Storage.Blob;
@@ -11,20 +11,14 @@ namespace SixLabors.ImageSharp.Web.Providers
     public class AzureBlobStorageImageProviderOptions
     {
         /// <summary>
-        /// Gets or sets the connection string.
+        /// Gets or sets the Azure Blob Storage connection string.
         /// </summary>
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Gets or sets the container name.
-        /// Must conform to Azure Blob Storage containiner naming guidlines.
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names"/>
+        /// Gets or sets the route prefix for processing azure assets.
+        /// Url format would be: /{RoutePrefix}/{ContainerName}/{FileName}
         /// </summary>
-        public string ContainerName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value indicating the level of public access that is allowed on the container.
-        /// </summary>
-        public BlobContainerPublicAccessType AccessType { get; set; } = BlobContainerPublicAccessType.Blob;
+        public string RoutePrefix { get; set; }
     }
 }

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStoragePathParts.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStoragePathParts.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStoragePathParts.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStoragePathParts.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SixLabors.ImageSharp.Web.Providers
+{
+    /// <summary>
+    /// Components of Azure blob URL path
+    /// </summary>
+    public class AzureBlobStoragePathParts
+    {
+        /// <summary>
+        /// Character array to remove from paths.
+        /// </summary>
+        private static readonly char[] SlashChars = { '\\', '/' };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobStoragePathParts"/> class.
+        /// </summary>
+        /// <param name="path">URL path to parse</param>
+        /// <param name="routePrefix">Azure route prefix</param>
+        public AzureBlobStoragePathParts(string path, string routePrefix)
+        {
+            this.RoutePrefix = routePrefix;
+
+            this.GetPartsForPath(path);
+        }
+
+        /// <summary>
+        /// Gets the route prefix
+        /// </summary>
+        public string RoutePrefix { get; private set; }
+
+        /// <summary>
+        /// Gets the Azure Blob Container name.
+        /// </summary>
+        public string ContainerName { get; private set; }
+
+        /// <summary>
+        /// Gets the Azue Blob File Name. Null if one could not be found
+        /// </summary>
+        public string BlobFilename { get; private set; }
+
+        private void GetPartsForPath(string path)
+        {
+            // Strip the leading slash and route prefix from the HTTP request path
+            // Path has already been correctly parsed before here.
+            string pathMinusPrefix = path.TrimStart(SlashChars)
+                                     .Substring(this.RoutePrefix.Length)
+                                     .TrimStart(SlashChars);
+
+            // Split path into container and blob filename
+            foreach (char slash in SlashChars)
+            {
+                int indexOfSlash = pathMinusPrefix.IndexOf(slash);
+
+                if (indexOfSlash < 0 || pathMinusPrefix.Length <= (indexOfSlash + 1))
+                {
+                    continue;
+                }
+
+                this.ContainerName = pathMinusPrefix.Substring(0, indexOfSlash);
+                this.BlobFilename = pathMinusPrefix.Substring(indexOfSlash + 1);
+
+                return;
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Azure/AzureBlobStoragePathPartsTests.cs
+++ b/tests/ImageSharp.Web.Tests/Azure/AzureBlobStoragePathPartsTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/ImageSharp.Web.Tests/Azure/AzureBlobStoragePathPartsTests.cs
+++ b/tests/ImageSharp.Web.Tests/Azure/AzureBlobStoragePathPartsTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using SixLabors.ImageSharp.Web.Providers;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Azure
+{
+    public class AzureBlobStoragePathPartsTests
+    {
+        private static readonly string RoutePrefix = "assets";
+
+        [Fact]
+        public void PathPartsContainerCorrect()
+        {
+            const string path = "/assets/products/productImage.jpg";
+
+            var pathParts = new AzureBlobStoragePathParts(path, RoutePrefix);
+
+            Assert.Equal("products", pathParts.ContainerName);
+        }
+
+        [Fact]
+        public void PathPartsBlobFilenameCorrect()
+        {
+            const string path = "/assets/products/productImage.jpg";
+
+            var pathParts = new AzureBlobStoragePathParts(path, RoutePrefix);
+
+            Assert.Equal("productImage.jpg", pathParts.BlobFilename);
+        }
+
+        [Fact]
+        public void PathPartsBlobFilenameWithSubFolderCorrect()
+        {
+            const string path = "/assets/products/1/productImage.jpg";
+
+            var pathParts = new AzureBlobStoragePathParts(path, RoutePrefix);
+
+            Assert.Equal("1/productImage.jpg", pathParts.BlobFilename);
+        }
+
+        [Fact]
+        public void PathPartsBlobFilenameNotFoundCorrect()
+        {
+            const string path = "/assets/products/";
+
+            var pathParts = new AzureBlobStoragePathParts(path, RoutePrefix);
+
+            Assert.Null(pathParts.BlobFilename);
+        }
+
+        [Fact]
+        public void PathPartsBlobFilenameNotFoundNoTrailingSlashCorrect()
+        {
+            const string path = "/assets/products";
+
+            var pathParts = new AzureBlobStoragePathParts(path, RoutePrefix);
+
+            Assert.Null(pathParts.BlobFilename);
+        }
+
+        [Fact]
+        public void PathPartsBlobFilenameWithForwardSlashCorrect()
+        {
+            const string path = "\\assets\\products\\productImage.jpg";
+
+            var pathParts = new AzureBlobStoragePathParts(path, RoutePrefix);
+
+            Assert.Equal("productImage.jpg", pathParts.BlobFilename);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
+++ b/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
@@ -27,9 +27,10 @@ namespace SixLabors.ImageSharp.Web.Tests
     {
         private const string AzureConnectionString = "UseDevelopmentStorage=true";
         private const string AzureContainerName = "azure";
+        private const string AzureRoutePrefix = "assets";
         private const string ImagePath = "SubFolder/imagesharp-logo.png";
         public const string PhysicalTestImage = "http://localhost/" + ImagePath;
-        public const string AzureTestImage = "http://localhost/" + AzureContainerName + "/" + ImagePath;
+        public const string AzureTestImage = "http://localhost/" + AzureRoutePrefix + "/" + AzureContainerName + "/" + ImagePath;
 
         public static Action<IApplicationBuilder> DefaultConfig = app => app.UseImageSharp();
 
@@ -55,7 +56,7 @@ namespace SixLabors.ImageSharp.Web.Tests
                     .Configure<AzureBlobStorageImageProviderOptions>(options =>
                     {
                         options.ConnectionString = AzureConnectionString;
-                        options.ContainerName = AzureContainerName;
+                        options.RoutePrefix = AzureRoutePrefix;
                     })
                     .AddProvider<AzureBlobStorageImageProvider>()
                     .AddProcessor<ResizeWebProcessor>();
@@ -89,7 +90,7 @@ namespace SixLabors.ImageSharp.Web.Tests
                 .Configure<AzureBlobStorageImageProviderOptions>(options =>
                 {
                     options.ConnectionString = AzureConnectionString;
-                    options.ContainerName = AzureContainerName;
+                    options.RoutePrefix = AzureRoutePrefix;
                 })
                 .AddProvider<AzureBlobStorageImageProvider>()
                 .AddProcessor<ResizeWebProcessor>();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The current AzureBlobStorageImageProvider only supports a single blob container. Many applications will want to utilize multiple containers. I've updated the AzureBlobStorageImageProvider to utilize a RoutePrefix and then to parse the container name and blob file name from the URL after the prefix.

So, an example URL with the corresponding parts would be:

https://localhost:9999/assets/products/productImage.jpg

Route Prefix: assets
Container Name: products
Blob Filename: productImage.jpg

The AzureBlobStorageImageProvider only matches on paths that start with the route prefix and then parses the URL to pull the container and blob file name.

I also removed the code for creating a new container if it doesn't exists because it seems like this should be a read-only operation and now actually adding containers in Azure. 