### PR TITLE
Add a setting so providers can process images when no commands are supplied.

### DIFF
--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         }
 
         /// <inheritdoc/>
-        public ProcessingBehavior ProcessingBehavior { get; set; } = ProcessingBehavior.All;
+        public ProcessingBehavior ProcessingBehavior { get; } = ProcessingBehavior.All;
 
         /// <inheritdoc/>
         public Func<HttpContext, bool> Match

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         }
 
         /// <inheritdoc/>
-        public bool ProcessWhenNoCommands { get; set; } = true;
+        public ProcessingBehavior ProcessingBehavior { get; set; } = ProcessingBehavior.All;
 
         /// <inheritdoc/>
         public Func<HttpContext, bool> Match

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
@@ -85,6 +85,9 @@ namespace SixLabors.ImageSharp.Web.Providers
         }
 
         /// <inheritdoc/>
+        public bool ProcessWhenNoCommands { get; set; } = true;
+
+        /// <inheritdoc/>
         public Func<HttpContext, bool> Match
         {
             get => this.match ?? this.IsMatch;

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -180,7 +180,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 }
             }
 
-            if ((commands.Count == 0 && provider?.ProcessWhenNoCommands != true) || provider?.IsValidRequest(context) != true)
+            if ((commands.Count == 0 && provider?.ProcessingBehavior != ProcessingBehavior.All) || provider?.IsValidRequest(context) != true)
             {
                 // Nothing to do. call the next delegate/middleware in the pipeline
                 await this.next(context).ConfigureAwait(false);

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -169,13 +169,6 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
             this.options.OnParseCommands?.Invoke(new ImageCommandContext(context, commands, CommandParser.Instance));
 
-            if (commands.Count == 0)
-            {
-                // Nothing to do. call the next delegate/middleware in the pipeline
-                await this.next(context).ConfigureAwait(false);
-                return;
-            }
-
             // Get the correct service for the request.
             IImageProvider provider = null;
             foreach (IImageProvider resolver in this.providers)
@@ -187,7 +180,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 }
             }
 
-            if (provider?.IsValidRequest(context) != true)
+            if ((commands.Count == 0 && provider?.ProcessWhenNoCommands != true) || provider?.IsValidRequest(context) != true)
             {
                 // Nothing to do. call the next delegate/middleware in the pipeline
                 await this.next(context).ConfigureAwait(false);

--- a/src/ImageSharp.Web/Providers/IImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/IImageProvider.cs
@@ -15,6 +15,12 @@ namespace SixLabors.ImageSharp.Web.Providers
     public interface IImageProvider
     {
         /// <summary>
+        /// Gets or sets a value indicating whether this provider should process
+        /// an image when no commands have been supplied.
+        /// </summary>
+        bool ProcessWhenNoCommands { get; set; }
+
+        /// <summary>
         /// Gets or sets the method used by the resolver to identify itself as the correct resolver to use.
         /// </summary>
         Func<HttpContext, bool> Match { get; set; }

--- a/src/ImageSharp.Web/Providers/IImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/IImageProvider.cs
@@ -15,10 +15,9 @@ namespace SixLabors.ImageSharp.Web.Providers
     public interface IImageProvider
     {
         /// <summary>
-        /// Gets or sets a value indicating whether this provider should process
-        /// an image when no commands have been supplied.
+        /// Gets the processing behavior.
         /// </summary>
-        bool ProcessWhenNoCommands { get; set; }
+        ProcessingBehavior ProcessingBehavior { get; }
 
         /// <summary>
         /// Gets or sets the method used by the resolver to identify itself as the correct resolver to use.

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         }
 
         /// <inheritdoc/>
-        public bool ProcessWhenNoCommands { get; set; } = false;
+        public ProcessingBehavior ProcessingBehavior { get; set; } = ProcessingBehavior.CommandOnly;
 
         /// <inheritdoc/>
         public Func<HttpContext, bool> Match { get; set; } = _ => true;

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         }
 
         /// <inheritdoc/>
-        public ProcessingBehavior ProcessingBehavior { get; set; } = ProcessingBehavior.CommandOnly;
+        public ProcessingBehavior ProcessingBehavior { get; } = ProcessingBehavior.CommandOnly;
 
         /// <inheritdoc/>
         public Func<HttpContext, bool> Match { get; set; } = _ => true;

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -42,6 +42,9 @@ namespace SixLabors.ImageSharp.Web.Providers
         }
 
         /// <inheritdoc/>
+        public bool ProcessWhenNoCommands { get; set; } = false;
+
+        /// <inheritdoc/>
         public Func<HttpContext, bool> Match { get; set; } = _ => true;
 
         /// <inheritdoc/>

--- a/src/ImageSharp.Web/Providers/ProcessingBehavior.cs
+++ b/src/ImageSharp.Web/Providers/ProcessingBehavior.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Web.Providers
+{
+    /// <summary>
+    /// Enumerates the possible processing behaviors.
+    /// </summary>
+    public enum ProcessingBehavior
+    {
+        /// <summary>
+        /// The image will be processed only when commands are supplied.
+        /// </summary>
+        CommandOnly,
+
+        /// <summary>
+        /// The image will always be processed.
+        /// </summary>
+        All
+    }
+}

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/MockImageProvider.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/MockImageProvider.cs
@@ -11,7 +11,7 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
 {
     public class MockImageProvider : IImageProvider
     {
-        public bool ProcessWhenNoCommands { get; set; } = true;
+        public ProcessingBehavior ProcessingBehavior { get; set; } = ProcessingBehavior.All;
 
         public Func<HttpContext, bool> Match { get; set; } = _ => true;
 

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/MockImageProvider.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/MockImageProvider.cs
@@ -11,6 +11,8 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
 {
     public class MockImageProvider : IImageProvider
     {
+        public bool ProcessWhenNoCommands { get; set; } = true;
+
         public Func<HttpContext, bool> Match { get; set; } = _ => true;
 
         public Task<IImageResolver> GetAsync(HttpContext context) => Task.FromResult<IImageResolver>(null);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

Addresses #77 

This exposes a setting on individual providers to determine whether they should continue processing an image when no commands are supplied. This is important for remote providers - such as the `AzureBlobStorageImageProvider` - as they are unable to fall back on the static files middleware to serve images.