### PR TITLE
Copy Azure stream to prevent read errors

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,7 +22,7 @@
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
 
     <!--Src Dependencies-->
-    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-unstable0542" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-unstable0591" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.1" />
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="10.0.2" />
   </ItemGroup>

--- a/ImageSharp.Web.sln
+++ b/ImageSharp.Web.sln
@@ -6,7 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
 		ci-build.ps1 = ci-build.ps1
+		ci-pack.ps1 = ci-pack.ps1
 		ci-test.ps1 = ci-test.ps1
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
 		Directory.Build.props = Directory.Build.props
@@ -36,6 +38,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageSharp.Web.Benchmarks", "tests\ImageSharp.Web.Benchmarks\ImageSharp.Web.Benchmarks.csproj", "{0B15E490-7821-42DF-86A5-4DEAE921DE59}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageSharp.Web.Providers.Azure", "src\ImageSharp.Web.Providers.Azure\ImageSharp.Web.Providers.Azure.csproj", "{E2A545EC-B909-4EAD-B95F-397F68588BE3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{B8152C86-B657-4967-B297-42F89A10D23A}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -104,6 +111,7 @@ Global
 		{8864C96C-94AA-454D-BAF5-779216C3745A} = {56801022-D71A-4FBE-BC5B-CBA08E2284EC}
 		{0B15E490-7821-42DF-86A5-4DEAE921DE59} = {56801022-D71A-4FBE-BC5B-CBA08E2284EC}
 		{E2A545EC-B909-4EAD-B95F-397F68588BE3} = {815C0625-CD3D-440F-9F80-2D83856AB7AE}
+		{B8152C86-B657-4967-B297-42F89A10D23A} = {C317F1B1-D75E-4C6D-83EB-80367343E0D7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5B38B65-A19E-4359-859C-5B2205429BD1}

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 <h1 align="center">
 
-<img src="https://raw.githubusercontent.com/SixLabors/Branding/master/icons/imagesharp/sixlabors.imagesharp.512.png" alt="SixLabors.ImageSharp.Web" width="256"/>
+<img src="https://raw.githubusercontent.com/SixLabors/Branding/master/icons/imagesharp.web/sixlabors.imagesharp.web.512.png" alt="SixLabors.ImageSharp.Web" width="256"/>
 <br/>
 SixLabors.ImageSharp.Web
 </h1>
 
 <div align="center">
 
+[![Build Status](https://img.shields.io/github/workflow/status/SixLabors/ImageSharp.Web/Build/master)](https://github.com/SixLabors/ImageSharp.Web/actions)
+[![Code coverage](https://codecov.io/gh/SixLabors/ImageSharp.Web/branch/master/graph/badge.svg)](https://codecov.io/gh/SixLabors/ImageSharp.Web)
 [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/SixLabors/ImageSharp.Web/master/APACHE-2.0-LICENSE.txt)
 [![GitHub issues](https://img.shields.io/github/issues/SixLabors/ImageSharp.Web.svg)](https://github.com/SixLabors/ImageSharp.Web/issues)
 [![GitHub stars](https://img.shields.io/github/stars/SixLabors/ImageSharp.Web.svg)](https://github.com/SixLabors/ImageSharp.Web/stargazers)
+
 [![GitHub forks](https://img.shields.io/github/forks/SixLabors/ImageSharp.Web.svg)](https://github.com/SixLabors/ImageSharp.Web/network)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ImageSharp/General?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 [![Twitter](https://img.shields.io/twitter/url/http/shields.io.svg?style=flat&logo=twitter)](https://twitter.com/intent/tweet?hashtags=imagesharp,dotnet,oss&text=ImageSharp.+A+new+cross-platform+2D+graphics+API+in+C%23&url=https%3a%2f%2fgithub.com%2fSixLabors%2fImageSharp&via=sixlabors)
 [![OpenCollective](https://opencollective.com/imagesharp/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/imagesharp/sponsors/badge.svg)](#sponsors)
@@ -22,12 +24,6 @@ SixLabors.ImageSharp.Web
 ### **ImageSharp.Web** is a new high-performance ASP.NET Core middleware leveraging the ImageSharp graphics library.
 
 > Pre-release downloads are available from the [MyGet package repository](https://www.myget.org/feed/sixlabors/package/nuget/SixLabors.ImageSharp.Web).
-
-
-|Build Status|Code Coverage|
-|:----------:|:-----------:|
-|[![Build Status](https://img.shields.io/github/workflow/status/SixLabors/ImageSharp.Web/Build/master)](https://github.com/SixLabors/ImageSharp.Web/actions)|[![Code coverage](https://codecov.io/gh/SixLabors/ImageSharp.Web/branch/master/graph/badge.svg)](https://codecov.io/gh/SixLabors/ImageSharp.Web)|
-
 
 ### Installation
 

--- a/ci-test.ps1
+++ b/ci-test.ps1
@@ -17,7 +17,7 @@ if ($codecov -eq 'true') {
 
   # Allow toggling of profile to workaround any potential JIT errors caused by code injection.
   dotnet clean -c $codecovProfile
-  dotnet test -c $codecovProfile -f $targetFramework /p:codecov=true
+  dotnet test --collect "XPlat Code Coverage" --settings .\tests\coverlet.runsettings -c $codecovProfile -f $targetFramework /p:CodeCov=true
 }
 elseif ($platform -eq '-x86' -and $targetFramework -match $netFxRegex) {
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# Documentation: https://docs.codecov.io/docs/codecov-yaml
+
+codecov:
+    # Avoid "Missing base report"
+    # https://github.com/codecov/support/issues/363
+    # https://docs.codecov.io/docs/comparing-commits
+    allow_coverage_offsets: true

--- a/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageImageResolver.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageImageResolver.cs
@@ -29,6 +29,15 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         }
 
         /// <inheritdoc/>
-        public Task<Stream> OpenReadAsync() => this.blob.OpenReadAsync();
+        public async Task<Stream> OpenReadAsync()
+        {
+            Stream blobStream = await this.blob.OpenReadAsync();
+            var memoryStream = new ChunkedMemoryStream();
+
+            await blobStream.CopyToAsync(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            return memoryStream;
+        }
     }
 }

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -258,7 +258,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                             // No allocations here for inStream since we are passing the raw input stream.
                             // outStream allocation depends on the memory allocator used.
                             ImageCacheMetadata cachedImageMetadata = default;
-                            outStream = new ChunkedMemoryStream(this.memoryAllocator);
+                            outStream = new ChunkedMemoryStream();
                             using (Stream inStream = await sourceImageResolver.OpenReadAsync().ConfigureAwait(false))
                             {
                                 IImageFormat format;

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -36,7 +36,6 @@
 
   <ItemGroup Condition="'$(codecov)' == 'true' AND '$(IsTestProject)' == 'true'">
     <PackageReference Include="coverlet.collector" IsImplicitlyDefined="true" />
-    <PackageReference Include="coverlet.msbuild" IsImplicitlyDefined="true" />
   </ItemGroup>
   
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -23,29 +23,13 @@
     <DotNetCliToolReference Update="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
-  <!--Code coverage specific settings-->
-  <!--https://github.com/tonerdo/coverlet-->
-  <PropertyGroup Condition="'$(codecov)' == 'true' AND '$(IsTestProject)' == 'true'">
-    <CollectCoverage>true</CollectCoverage>
-    <UseSourceLink>true</UseSourceLink>
-    <Include>[SixLabors.*]*</Include>
-    <CoverletOutputFormat>lcov</CoverletOutputFormat>
-    <!--Output injects target framework into name despite explicit config. See build yml-->
-    <CoverletOutputPath>$(MSBuildThisFileDirectory)..\</CoverletOutputPath>
-    <CoverletOutput>$(CoverletOutputPath)$(AssemblyName).$(TargetFramework).lcov</CoverletOutput>
-    <!--Used by coverlet dues to reference issues-->
-    <!--https://github.com/tonerdo/coverlet/blob/master/Documentation/KnowIssues.md#4-failed-to-resolve-assembly-during-instrumentation-->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
   <ItemGroup>
     <!--Test Dependencies-->
     <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Update="coverlet.collector" Version="1.1.0" PrivateAssets="All"/>
-    <PackageReference Update="coverlet.msbuild" Version="2.8.0" PrivateAssets="All"/>
+    <PackageReference Update="coverlet.collector" Version="1.2.0" PrivateAssets="All"/>
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.4" />
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="11.1.2" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200116-01" />
 
     <!--Don't update these. We're getting AmbiguousMatchException on Linux-->
     <!--See https://github.com/xunit/xunit/issues/1771-->

--- a/tests/ImageSharp.Web.Tests/ChunkedMemoryStreamTests.cs
+++ b/tests/ImageSharp.Web.Tests/ChunkedMemoryStreamTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -14,19 +14,16 @@ namespace SixLabors.ImageSharp.Web.Tests
     public class ChunkedMemoryStreamTests
     {
         [Fact]
-        public static void MemoryStream_Ctor_NullAllocator() => Assert.Throws<ArgumentNullException>(() => new ChunkedMemoryStream(null));
-
-        [Fact]
         public static void MemoryStream_Ctor_InvalidCapacities()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new ChunkedMemoryStream(Configuration.Default.MemoryAllocator, int.MinValue));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new ChunkedMemoryStream(Configuration.Default.MemoryAllocator, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ChunkedMemoryStream(int.MinValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ChunkedMemoryStream(0));
         }
 
         [Fact]
         public static void ChunkedMemoryStream_GetPositionTest_Negative()
         {
-            using (var ms = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+            using (var ms = new ChunkedMemoryStream())
             {
                 long iCurrentPos = ms.Position;
                 for (int i = -1; i > -6; i--)
@@ -40,7 +37,7 @@ namespace SixLabors.ImageSharp.Web.Tests
         [Fact]
         public static void MemoryStream_ReadTest_Negative()
         {
-            var ms2 = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator);
+            var ms2 = new ChunkedMemoryStream();
 
             Assert.Throws<ArgumentNullException>(() => ms2.Read(null, 0, 0));
             Assert.Throws<ArgumentOutOfRangeException>(() => ms2.Read(new byte[] { 1 }, -1, 0));
@@ -56,7 +53,7 @@ namespace SixLabors.ImageSharp.Web.Tests
         [Fact]
         public static void MemoryStream_WriteToTests()
         {
-            using (var ms2 = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+            using (var ms2 = new ChunkedMemoryStream())
             {
                 byte[] bytArrRet;
                 byte[] bytArr = new byte[] { byte.MinValue, byte.MaxValue, 1, 2, 3, 4, 5, 6, 128, 250 };
@@ -64,7 +61,7 @@ namespace SixLabors.ImageSharp.Web.Tests
                 // [] Write to FileStream, check the filestream
                 ms2.Write(bytArr, 0, bytArr.Length);
 
-                using (var readonlyStream = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+                using (var readonlyStream = new ChunkedMemoryStream())
                 {
                     ms2.WriteTo(readonlyStream);
                     readonlyStream.Flush();
@@ -79,8 +76,8 @@ namespace SixLabors.ImageSharp.Web.Tests
             }
 
             // [] Write to memoryStream, check the memoryStream
-            using (var ms2 = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
-            using (var ms3 = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+            using (var ms2 = new ChunkedMemoryStream())
+            using (var ms3 = new ChunkedMemoryStream())
             {
                 byte[] bytArrRet;
                 byte[] bytArr = new byte[] { byte.MinValue, byte.MaxValue, 1, 2, 3, 4, 5, 6, 128, 250 };
@@ -100,7 +97,7 @@ namespace SixLabors.ImageSharp.Web.Tests
         [Fact]
         public static void MemoryStream_WriteToTests_Negative()
         {
-            using (var ms2 = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+            using (var ms2 = new ChunkedMemoryStream())
             {
                 Assert.Throws<ArgumentNullException>(() => ms2.WriteTo(null));
 
@@ -120,7 +117,7 @@ namespace SixLabors.ImageSharp.Web.Tests
         {
             ChunkedMemoryStream memoryStream;
             const string bufferSize = "bufferSize";
-            using (memoryStream = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+            using (memoryStream = new ChunkedMemoryStream())
             {
                 const string destination = "destination";
                 Assert.Throws<ArgumentNullException>(destination, () => memoryStream.CopyTo(destination: null));
@@ -144,7 +141,7 @@ namespace SixLabors.ImageSharp.Web.Tests
             Assert.Throws<ObjectDisposedException>(() => memoryStream.CopyTo(disposedStream, 1));
 
             // Then for the destination being disposed.
-            memoryStream = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator);
+            memoryStream = new ChunkedMemoryStream();
             Assert.Throws<ObjectDisposedException>(() => memoryStream.CopyTo(disposedStream, 1));
         }
 
@@ -152,7 +149,7 @@ namespace SixLabors.ImageSharp.Web.Tests
         [MemberData(nameof(CopyToData))]
         public void CopyTo(Stream source, byte[] expected)
         {
-            using (var destination = new ChunkedMemoryStream(Configuration.Default.MemoryAllocator))
+            using (var destination = new ChunkedMemoryStream())
             {
                 source.CopyTo(destination);
                 Assert.InRange(source.Position, source.Length, int.MaxValue); // Copying the data should have read to the end of the stream or stayed past the end.

--- a/tests/coverlet.runsettings
+++ b/tests/coverlet.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="XPlat code coverage">
+                <Configuration>
+                    <Format>lcov</Format>
+                    <Include>[SixLabors.*]*</Include>
+                    <UseSourceLink>true</UseSourceLink>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
- Exposes `ChunkedMemoryStream` as a public type.
- Ensures entire Azure Blob stream is copied before processing.

<!-- Thanks for contributing to ImageSharp! -->
