### PR TITLE
AnchorPositionMode.Center is ignored when CenterCoordinates is Empty

### DIFF
--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -116,13 +116,13 @@ namespace SixLabors.ImageSharp.Web.Processors
             return new Size((int)width, (int)height);
         }
 
-        private static PointF GetCenter(IDictionary<string, string> commands, CommandParser parser)
+        private static PointF? GetCenter(IDictionary<string, string> commands, CommandParser parser)
         {
             float[] coordinates = parser.ParseValue<float[]>(commands.GetValueOrDefault(Xy));
 
             if (coordinates.Length != 2)
             {
-                return PointF.Empty;
+                return null;
             }
 
             return new PointF(coordinates[0], coordinates[1]);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
When cropping without specifying explicit 'rxy' in the url, the CenterCoordinates will be set to PointF.Empty and the AnchorPositionMode.Center will be ignored because ResizeHelper checks for CenterCoordinates.HasValue.

