### PR TITLE
Add Support for Multiple Azure Connections and Containers.

### DIFF
--- a/ImageSharp.Web.sln
+++ b/ImageSharp.Web.sln
@@ -45,6 +45,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{B815
 	EndProjectSection
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems*{2f1b36e2-5d92-4442-b816-d2a978246435}*SharedItemsImports = 5
+		shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems*{e2a545ec-b909-4ead-b95f-397f68588be3}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Http;
@@ -22,9 +23,10 @@ namespace SixLabors.ImageSharp.Web.Providers
         private static readonly char[] SlashChars = { '\\', '/' };
 
         /// <summary>
-        /// The container in the blob service.
+        /// The containers for the blob services.
         /// </summary>
-        private readonly BlobContainerClient container;
+        private readonly Dictionary<string, BlobContainerClient> containers
+            = new Dictionary<string, BlobContainerClient>();
 
         /// <summary>
         /// The blob storage options.
@@ -55,7 +57,12 @@ namespace SixLabors.ImageSharp.Web.Providers
             this.storageOptions = storageOptions.Value;
             this.formatUtilities = formatUtilities;
 
-            this.container = new BlobContainerClient(this.storageOptions.ConnectionString, this.storageOptions.ContainerName);
+            foreach (AzureBlobContainerClientOptions container in this.storageOptions.BlobContainers)
+            {
+                this.containers.Add(
+                    container.ContainerName,
+                    new BlobContainerClient(container.ConnectionString, container.ContainerName));
+            }
         }
 
         /// <inheritdoc/>
@@ -74,16 +81,35 @@ namespace SixLabors.ImageSharp.Web.Providers
             // Strip the leading slash and container name from the HTTP request path and treat
             // the remaining path string as the blob name.
             // Path has already been correctly parsed before here.
-            string blobName = context.Request.Path.Value.TrimStart(SlashChars)
-                                     .Substring(this.storageOptions.ContainerName.Length)
-                                     .TrimStart(SlashChars);
+            string containerName = string.Empty;
+            BlobContainerClient container = null;
+
+            string path = context.Request.Path.Value.TrimStart(SlashChars);
+            foreach (string key in this.containers.Keys)
+            {
+                if (path.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    containerName = key;
+                    container = this.containers[key];
+                    break;
+                }
+            }
+
+            // Something has gone horribly wrong for this to happen but check anyway.
+            if (container is null)
+            {
+                return null;
+            }
+
+            // Blob name should be the remaining path string.
+            string blobName = path.Substring(containerName.Length).TrimStart(SlashChars);
 
             if (string.IsNullOrWhiteSpace(blobName))
             {
                 return null;
             }
 
-            BlobClient blob = this.container.GetBlobClient(blobName);
+            BlobClient blob = container.GetBlobClient(blobName);
 
             if (!await blob.ExistsAsync())
             {
@@ -100,7 +126,15 @@ namespace SixLabors.ImageSharp.Web.Providers
         private bool IsMatch(HttpContext context)
         {
             string path = context.Request.Path.Value.TrimStart(SlashChars);
-            return path.StartsWith(this.storageOptions.ContainerName, StringComparison.OrdinalIgnoreCase);
+            foreach (string container in this.containers.Keys)
+            {
+                if (path.StartsWith(container, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
@@ -84,10 +84,15 @@ namespace SixLabors.ImageSharp.Web.Providers
             string containerName = string.Empty;
             BlobContainerClient container = null;
 
+            // We want an exact match here to ensure that container names starting with
+            // the same prefix are not mixed up.
             string path = context.Request.Path.Value.TrimStart(SlashChars);
+            int index = path.IndexOfAny(SlashChars);
+            string nameToMatch = index != -1 ? path.Substring(index) : path;
+
             foreach (string key in this.containers.Keys)
             {
-                if (path.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+                if (nameToMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                 {
                     containerName = key;
                     container = this.containers[key];
@@ -125,6 +130,8 @@ namespace SixLabors.ImageSharp.Web.Providers
 
         private bool IsMatch(HttpContext context)
         {
+            // Only match loosly here for performance.
+            // Path matching conflicts should be dealt with by configuration.
             string path = context.Request.Path.Value.TrimStart(SlashChars);
             foreach (string container in this.containers.Keys)
             {

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Generic;
+
 namespace SixLabors.ImageSharp.Web.Providers
 {
     /// <summary>
@@ -9,12 +11,23 @@ namespace SixLabors.ImageSharp.Web.Providers
     public class AzureBlobStorageImageProviderOptions
     {
         /// <summary>
-        /// Gets or sets the connection string.
+        /// Gets or sets the collection of blob container client options.
+        /// </summary>
+        public ICollection<AzureBlobContainerClientOptions> BlobContainers { get; set; } = new HashSet<AzureBlobContainerClientOptions>();
+    }
+
+    /// <summary>
+    /// Represents a single Azure Blob Storage connection and container.
+    /// </summary>
+    public class AzureBlobContainerClientOptions
+    {
+        /// <summary>
+        /// Gets or sets the Azure Blob Storage connection string.
         /// </summary>
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Gets or sets the container name.
+        /// Gets or sets the Azure Blob Storage container name.
         /// Must conform to Azure Blob Storage containiner naming guidlines.
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names"/>
         /// </summary>

--- a/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
+++ b/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
@@ -53,8 +53,11 @@ namespace SixLabors.ImageSharp.Web.Tests
                     .AddProvider(PhysicalProviderFactory)
                     .Configure<AzureBlobStorageImageProviderOptions>(options =>
                     {
-                        options.ConnectionString = AzureConnectionString;
-                        options.ContainerName = AzureContainerName;
+                        options.BlobContainers.Add(new AzureBlobContainerClientOptions
+                        {
+                            ConnectionString = AzureConnectionString,
+                            ContainerName = AzureContainerName
+                        });
                     })
                     .AddProvider<AzureBlobStorageImageProvider>()
                     .AddProcessor<ResizeWebProcessor>();
@@ -80,8 +83,11 @@ namespace SixLabors.ImageSharp.Web.Tests
                     .SetCacheHash<CacheHash>()
                     .Configure<AzureBlobStorageImageProviderOptions>(options =>
                     {
-                        options.ConnectionString = AzureConnectionString;
-                        options.ContainerName = AzureContainerName;
+                        options.BlobContainers.Add(new AzureBlobContainerClientOptions
+                        {
+                            ConnectionString = AzureConnectionString,
+                            ContainerName = AzureContainerName
+                        });
                     })
                     .AddProvider<AzureBlobStorageImageProvider>()
                     .AddProcessor<ResizeWebProcessor>();
@@ -116,8 +122,11 @@ namespace SixLabors.ImageSharp.Web.Tests
                 .AddProvider(PhysicalProviderFactory)
                 .Configure<AzureBlobStorageImageProviderOptions>(options =>
                 {
-                    options.ConnectionString = AzureConnectionString;
-                    options.ContainerName = AzureContainerName;
+                    options.BlobContainers.Add(new AzureBlobContainerClientOptions
+                    {
+                        ConnectionString = AzureConnectionString,
+                        ContainerName = AzureContainerName
+                    });
                 })
                 .AddProvider<AzureBlobStorageImageProvider>()
                 .AddProcessor<ResizeWebProcessor>();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Replaces #82 by @agrigg  due to merge conflicts and churn.

It's now possible to configure multiple Azure Blob Containers for the provider. 

The provider will resolve containers in the following format.
```
/{CONTAINER_NAME}/{BLOB_FILENAME} 
```
Care has been taken to ensure that container name matching is exact when resolving the correct container to retrieve from so multiple containers beginning with the same prefix will be matched.

Configuration via the fluent API is as follows: 

```c#
.Configure<AzureBlobStorageImageProviderOptions>(options =>
{
    options.BlobContainers.Add(new AzureBlobContainerClientOptions
    {
        ConnectionString = {AZURE_CONNECTION_STRING},
        ContainerName = {AZURE_CONTAINER_NAME}
    });
})
```

<!-- Thanks for contributing to ImageSharp! -->
