### PR TITLE
Move namespaces to fix docs conflict.

### DIFF
--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProvider.cs
@@ -9,8 +9,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp.Web.Resolvers;
+using SixLabors.ImageSharp.Web.Resolvers.Azure;
 
-namespace SixLabors.ImageSharp.Web.Providers
+namespace SixLabors.ImageSharp.Web.Providers.Azure
 {
     /// <summary>
     /// Returns images stored in Azure Blob Storage.

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace SixLabors.ImageSharp.Web.Providers
+namespace SixLabors.ImageSharp.Web.Providers.Azure
 {
     /// <summary>
     /// Configuration options for the <see cref="AzureBlobStorageImageProvider"/> provider.

--- a/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageImageResolver.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageImageResolver.cs
@@ -8,7 +8,7 @@ using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
-namespace SixLabors.ImageSharp.Web.Resolvers
+namespace SixLabors.ImageSharp.Web.Resolvers.Azure
 {
     /// <summary>
     /// Provides means to manage image buffers within the Azure Blob file system.

--- a/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
+++ b/tests/ImageSharp.Web.Tests/ImageSharpTestServer.cs
@@ -19,6 +19,7 @@ using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Providers;
+using SixLabors.ImageSharp.Web.Providers.Azure;
 
 namespace SixLabors.ImageSharp.Web.Tests
 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Migrates the Azure Provider APIs to new `**.Azure` namespace to remove API docs conflict.

<!-- Thanks for contributing to ImageSharp! -->
