### PR TITLE
Pass correct type parameter to background color processor.

### DIFF
--- a/samples/ImageSharp.Web.Sample/ImageSharp.Web.Sample.csproj
+++ b/samples/ImageSharp.Web.Sample/ImageSharp.Web.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0-unstable0044" />
+    <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0-unstable0056" />
   </ItemGroup>
 
 </Project>

--- a/src/ImageSharp.Web/Processors/BackgroundColorWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/BackgroundColorWebProcessor.cs
@@ -31,7 +31,7 @@ namespace SixLabors.ImageSharp.Web.Processors
         /// <inheritdoc/>
         public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands)
         {
-            Rgba32 background = CommandParser.Instance.ParseValue<Rgba32>(commands.GetValueOrDefault(Color));
+            Color background = CommandParser.Instance.ParseValue<Color>(commands.GetValueOrDefault(Color));
 
             if (background != default)
             {

--- a/tests/ImageSharp.Web.Tests/Commands/CommandParserTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/CommandParserTests.cs
@@ -73,7 +73,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
             { new List<float> { 1.667F, 2.667F, 3.667F, 4.667F }, "1.667,2.667,3.667,4.667" },
         };
 
-        public static TheoryData<object, string> Rgba32Values = new TheoryData<object, string>
+        public static TheoryData<object, string> ColorValues = new TheoryData<object, string>
         {
             { Color.White, "255,255,255" },
             { Color.Transparent, "0,0,0,0" },
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
         [MemberData(nameof(RealArrays))]
         [MemberData(nameof(IntegralLists))]
         [MemberData(nameof(RealLists))]
-        [MemberData(nameof(Rgba32Values))]
+        [MemberData(nameof(ColorValues))]
         public void CommandParses<T>(T expected, string param)
         {
             T sb = CommandParser.Instance.ParseValue<T>(param);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Bad type parameter passing for the background color processor. Fix #96

<!-- Thanks for contributing to ImageSharp! -->
