### PR TITLE
Allow the ability to set the quality of jpegs.

### DIFF
--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -58,7 +58,8 @@ namespace SixLabors.ImageSharp.Web.Sample
                 .AddProvider<PhysicalFileSystemProvider>()
                 .AddProcessor<ResizeWebProcessor>()
                 .AddProcessor<FormatWebProcessor>()
-                .AddProcessor<BackgroundColorWebProcessor>();
+                .AddProcessor<BackgroundColorWebProcessor>()
+                .AddProcessor<JpegQualityWebProcessor>();
 
             // Add the default service and options.
             //
@@ -134,7 +135,8 @@ namespace SixLabors.ImageSharp.Web.Sample
                 .ClearProcessors()
                 .AddProcessor<ResizeWebProcessor>()
                 .AddProcessor<FormatWebProcessor>()
-                .AddProcessor<BackgroundColorWebProcessor>();
+                .AddProcessor<BackgroundColorWebProcessor>()
+                .AddProcessor<JpegQualityWebProcessor>();
         }
 
         /// <summary>

--- a/samples/ImageSharp.Web.Sample/wwwroot/index.html
+++ b/samples/ImageSharp.Web.Sample/wwwroot/index.html
@@ -129,6 +129,34 @@
         </section>
         <hr />
         <section>
+            <h2>Jpeg Quality</h2>
+            <div>
+                <p>
+                    <code>imagesharp-logo.png?width=300&format=jpg&quality=100</code>
+                </p>
+                <p>
+                    <img src="imagesharp-logo.png?width=300&format=jpg&quality=100" />
+                </p>
+            </div>
+            <div>
+                <p>
+                    <code>imagesharp-logo.png?width=300&format=jpg&quality=50</code>
+                </p>
+                <p>
+                    <img src="imagesharp-logo.png?width=300&format=jpg&quality=50" />
+                </p>
+            </div>
+            <div>
+                <p>
+                    <code>imagesharp-logo.png?width=300&format=jpg&quality=1</code>
+                </p>
+                <p>
+                    <img src="imagesharp-logo.png?width=300&format=jpg&quality=1" />
+                </p>
+            </div>
+        </section>
+        <hr />
+        <section>
             <h2>Background Color</h2>
             <div>
                 <p>

--- a/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
@@ -67,7 +67,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
 
             builder.AddProcessor<ResizeWebProcessor>()
                    .AddProcessor<FormatWebProcessor>()
-                   .AddProcessor<BackgroundColorWebProcessor>();
+                   .AddProcessor<BackgroundColorWebProcessor>()
+                   .AddProcessor<JpegQualityWebProcessor>();
 
             builder.AddConverter<IntegralNumberConverter<sbyte>>();
             builder.AddConverter<IntegralNumberConverter<byte>>();

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Web
             {
                 if (value is null)
                 {
-                    ThrowInvalid(nameof(value));
+                    ThrowNull(nameof(value));
                 }
 
                 this.format = value;
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.Web
             {
                 if (value is null)
                 {
-                    ThrowInvalid(nameof(value));
+                    ThrowNull(nameof(value));
                 }
 
                 // The given type should match the format encoder.
@@ -108,6 +108,9 @@ namespace SixLabors.ImageSharp.Web
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowInvalid(string name) => throw new ArgumentNullException(name);
+        private static void ThrowNull(string name) => throw new ArgumentNullException(name);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalid(string name) => throw new ArgumentException(name);
     }
 }

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -11,10 +13,12 @@ namespace SixLabors.ImageSharp.Web
     /// <summary>
     /// A class encapsulating an image with a particular file encoding.
     /// </summary>
-    /// <seealso cref="IDisposable" />
+    /// <seealso cref="IDisposable"/>
     public sealed class FormattedImage : IDisposable
     {
+        private readonly ImageFormatManager imageFormatsManager;
         private IImageFormat format;
+        private IImageEncoder encoder;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FormattedImage"/> class.
@@ -23,8 +27,9 @@ namespace SixLabors.ImageSharp.Web
         /// <param name="format">The format.</param>
         internal FormattedImage(Image<Rgba32> image, IImageFormat format)
         {
-            this.format = format;
             this.Image = image;
+            this.imageFormatsManager = image.GetConfiguration().ImageFormatsManager;
+            this.Format = format;
         }
 
         /// <summary>
@@ -38,7 +43,40 @@ namespace SixLabors.ImageSharp.Web
         public IImageFormat Format
         {
             get => this.format;
-            set => this.format = value ?? throw new ArgumentNullException(nameof(value));
+            set
+            {
+                if (value is null)
+                {
+                    ThrowInvalid(nameof(value));
+                }
+
+                this.format = value;
+                this.encoder = this.imageFormatsManager.FindEncoder(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the encoder.
+        /// </summary>
+        public IImageEncoder Encoder
+        {
+            get => this.encoder;
+            set
+            {
+                if (value is null)
+                {
+                    ThrowInvalid(nameof(value));
+                }
+
+                // The given type should match the format encoder.
+                IImageEncoder reference = this.imageFormatsManager.FindEncoder(this.Format);
+                if (reference.GetType() != value.GetType())
+                {
+                    ThrowInvalid(nameof(value));
+                }
+
+                this.encoder = value;
+            }
         }
 
         /// <summary>
@@ -54,18 +92,22 @@ namespace SixLabors.ImageSharp.Web
         }
 
         /// <summary>
-        /// Saves the specified destination.
+        /// Saves image to the specified destination stream.
         /// </summary>
-        /// <param name="destination">The destination.</param>
-        public void Save(Stream destination) => this.Image.Save(destination, this.format);
+        /// <param name="destination">The destination stream.</param>
+        public void Save(Stream destination) => this.Image.Save(destination, this.encoder);
 
         /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting
+        /// unmanaged resources.
         /// </summary>
         public void Dispose()
         {
             this.Image?.Dispose();
             this.Image = null;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalid(string name) => throw new ArgumentNullException(name);
     }
 }

--- a/src/ImageSharp.Web/Middleware/ImageProcessingContext.cs
+++ b/src/ImageSharp.Web/Middleware/ImageProcessingContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors.
+// Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
@@ -18,7 +18,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// <param name="context">The current HTTP request context.</param>
         /// <param name="stream">The stream containing the processed image bytes.</param>
         /// <param name="commands">The parsed collection of processing commands.</param>
-        /// <param name="contentType">The content type for for the processed image..</param>
+        /// <param name="contentType">The content type for the processed image.</param>
         /// <param name="extension">The file extension for the processed image.</param>
         public ImageProcessingContext(
             HttpContext context,

--- a/src/ImageSharp.Web/Processors/FormatWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/FormatWebProcessor.cs
@@ -56,7 +56,8 @@ namespace SixLabors.ImageSharp.Web.Processors
 
             if (!string.IsNullOrWhiteSpace(extension))
             {
-                IImageFormat format = this.options.Configuration.ImageFormatsManager.FindFormatByFileExtension(extension);
+                IImageFormat format = this.options.Configuration
+                    .ImageFormatsManager.FindFormatByFileExtension(extension);
 
                 if (format != null)
                 {

--- a/src/ImageSharp.Web/Processors/JpegQualityWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/JpegQualityWebProcessor.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Web.Commands;
+
+namespace SixLabors.ImageSharp.Web.Processors
+{
+    /// <summary>
+    /// Allows the setting of quality for the jpeg image format.
+    /// </summary>
+    public class JpegQualityWebProcessor : IImageWebProcessor
+    {
+        /// <summary>
+        /// The command constant for quality.
+        /// </summary>
+        public const string Quality = "quality";
+
+        /// <summary>
+        /// The reusable collection of commands.
+        /// </summary>
+        private static readonly IEnumerable<string> QualityCommands
+            = new[] { Quality };
+
+        /// <inheritdoc/>
+        public IEnumerable<string> Commands { get; } = QualityCommands;
+
+        /// <inheritdoc/>
+        public FormattedImage Process(
+            FormattedImage image,
+            ILogger logger,
+            IDictionary<string, string> commands,
+            CommandParser parser,
+            CultureInfo culture)
+        {
+            if (commands.ContainsKey(Quality) && image.Format is JpegFormat)
+            {
+                // The encoder clamps any values so no validation is required.
+                int quality = parser.ParseValue<int>(commands.GetValueOrDefault(Quality), culture);
+                image.Encoder = new JpegEncoder() { Quality = quality };
+            }
+
+            return image;
+        }
+    }
+}

--- a/src/ImageSharp.Web/Processors/JpegQualityWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/JpegQualityWebProcessor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Web.Commands;
 
@@ -38,9 +39,19 @@ namespace SixLabors.ImageSharp.Web.Processors
         {
             if (commands.ContainsKey(Quality) && image.Format is JpegFormat)
             {
+                var reference =
+                    (JpegEncoder)image.Image
+                    .GetConfiguration()
+                    .ImageFormatsManager
+                    .FindEncoder(image.Format);
+
                 // The encoder clamps any values so no validation is required.
                 int quality = parser.ParseValue<int>(commands.GetValueOrDefault(Quality), culture);
-                image.Encoder = new JpegEncoder() { Quality = quality };
+
+                if (quality != reference.Quality)
+                {
+                    image.Encoder = new JpegEncoder() { Quality = quality, Subsample = reference.Subsample };
+                }
             }
 
             return image;

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -28,6 +28,7 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
             Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(ResizeWebProcessor));
             Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(FormatWebProcessor));
             Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(BackgroundColorWebProcessor));
+            Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(JpegQualityWebProcessor));
             Assert.Contains(services, x => x.ServiceType == typeof(CommandParser));
 
             Assert.Contains(services, x => x.ServiceType == typeof(ICommandConverter) && x.ImplementationType == typeof(IntegralNumberConverter<sbyte>));

--- a/tests/ImageSharp.Web.Tests/Processors/FormattedImageTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/FormattedImageTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Processors
+{
+    public class FormattedImageTests
+    {
+        [Fact]
+        public void ConstructorSetsProperties()
+        {
+            using var image = new Image<Rgba32>(1, 1);
+            using var formatted = new FormattedImage(image, JpegFormat.Instance);
+
+            Assert.NotNull(formatted.Image);
+            Assert.Equal(image, formatted.Image);
+
+            Assert.NotNull(formatted.Format);
+            Assert.Equal(JpegFormat.Instance, formatted.Format);
+
+            Assert.NotNull(formatted.Encoder);
+            Assert.Equal(typeof(JpegEncoder), formatted.Encoder.GetType());
+        }
+
+        [Fact]
+        public void CanSetFormat()
+        {
+            using var image = new Image<Rgba32>(1, 1);
+            using var formatted = new FormattedImage(image, JpegFormat.Instance);
+
+            Assert.NotNull(formatted.Format);
+            Assert.Equal(JpegFormat.Instance, formatted.Format);
+
+            Assert.Throws<ArgumentNullException>(() => formatted.Format = null);
+
+            formatted.Format = PngFormat.Instance;
+            Assert.Equal(PngFormat.Instance, formatted.Format);
+            Assert.Equal(typeof(PngEncoder), formatted.Encoder.GetType());
+        }
+
+        [Fact]
+        public void CanSetEncoder()
+        {
+            using var image = new Image<Rgba32>(1, 1);
+            using var formatted = new FormattedImage(image, PngFormat.Instance);
+
+            Assert.NotNull(formatted.Format);
+            Assert.Equal(PngFormat.Instance, formatted.Format);
+
+            Assert.Throws<ArgumentNullException>(() => formatted.Encoder = null);
+            Assert.Throws<ArgumentException>(() => formatted.Encoder = new JpegEncoder());
+
+            formatted.Format = JpegFormat.Instance;
+            Assert.Equal(typeof(JpegEncoder), formatted.Encoder.GetType());
+
+            JpegSubsample current = ((JpegEncoder)formatted.Encoder).Subsample.GetValueOrDefault();
+
+            Assert.Equal(JpegSubsample.Ratio444, current);
+            formatted.Encoder = new JpegEncoder { Subsample = JpegSubsample.Ratio420 };
+
+            JpegSubsample replacement = ((JpegEncoder)formatted.Encoder).Subsample.GetValueOrDefault();
+
+            Assert.NotEqual(current, replacement);
+            Assert.Equal(JpegSubsample.Ratio420, replacement);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Processors/JpegQualityWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/JpegQualityWebProcessorTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Globalization;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Web.Commands;
+using SixLabors.ImageSharp.Web.Commands.Converters;
+using SixLabors.ImageSharp.Web.Processors;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Processors
+{
+    public class JpegQualityWebProcessorTests
+    {
+        [Fact]
+        public void JpegQualityWebProcessor_UpdatesQuality()
+        {
+            var parser = new CommandParser(new[] { new IntegralNumberConverter<int>() });
+            CultureInfo culture = CultureInfo.InvariantCulture;
+
+            var commands = new Dictionary<string, string>
+            {
+                { JpegQualityWebProcessor.Quality, "42" },
+            };
+
+            using var image = new Image<Rgba32>(1, 1);
+            using var formatted = new FormattedImage(image, JpegFormat.Instance);
+            Assert.Equal(JpegFormat.Instance, formatted.Format);
+            Assert.Equal(typeof(JpegEncoder), formatted.Encoder.GetType());
+
+            new JpegQualityWebProcessor()
+                .Process(formatted, null, commands, parser, culture);
+
+            Assert.Equal(JpegFormat.Instance, formatted.Format);
+            Assert.Equal(42, ((JpegEncoder)formatted.Encoder).Quality);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageCacheTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageCacheTestServerFixture.cs
@@ -54,6 +54,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
                 {
                     Assert.NotNull(context);
                     Assert.NotNull(context.Format);
+                    Assert.NotNull(context.Encoder);
                     Assert.NotNull(context.Image);
 
                     return onBeforeSaveAsync.Invoke(context);

--- a/tests/ImageSharp.Web.Tests/TestUtilities/PhysicalFileSystemCacheTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/PhysicalFileSystemCacheTestServerFixture.cs
@@ -52,6 +52,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
                 {
                     Assert.NotNull(context);
                     Assert.NotNull(context.Format);
+                    Assert.NotNull(context.Encoder);
                     Assert.NotNull(context.Image);
 
                     return onBeforeSaveAsync.Invoke(context);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Introduces the ability to set the quality of jpegs per request. Commands are sent in the following manner.

See Discussion #123 for reference.

```
{PATH_TO_YOUR_IMAGE}?quality=50
{PATH_TO_YOUR_IMAGE}?format=jpg&quality=50
```

As we introduce image other image formats that support variable quality we can create format specific quality parsers that will not conflict with this one allowing the sharing of the same command key.

![image](https://user-images.githubusercontent.com/385879/93533593-32ddba00-f93b-11ea-85e0-4b706ff95dae.png)


<!-- Thanks for contributing to ImageSharp! -->
