### PR TITLE
Add an option to enable setting a different CacheRoot

### DIFF
--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -72,7 +72,7 @@ namespace SixLabors.ImageSharp.Web.Caching
 
             // Allow configuration of the cache without having to register everything.
             this.cacheOptions = cacheOptions != null ? cacheOptions.Value : new PhysicalFileSystemCacheOptions();
-            this.cacheRootPath = GetCacheRoot(this.cacheOptions, environment.WebRootPath);
+            this.cacheRootPath = GetCacheRoot(this.cacheOptions, environment.WebRootPath, environment.ContentRootPath);
             if (!Directory.Exists(this.cacheRootPath))
             {
                 Directory.CreateDirectory(this.cacheRootPath);
@@ -89,13 +89,17 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// </summary>
         /// <param name="cacheOptions">the cache options.</param>
         /// <param name="webRootPath">the webRootPath.</param>
+        /// <param name="contentRootPath">the contentRootPath.</param>
         /// <returns>root path.</returns>
-        internal static string GetCacheRoot(PhysicalFileSystemCacheOptions cacheOptions, string webRootPath)
+        internal static string GetCacheRoot(in PhysicalFileSystemCacheOptions cacheOptions, in string webRootPath, in string contentRootPath)
         {
             var cacheRoot = string.IsNullOrEmpty(cacheOptions.CacheRoot)
                 ? webRootPath
                 : cacheOptions.CacheRoot;
-            return Path.Combine(cacheRoot, cacheOptions.CacheFolder);
+
+            return Path.IsPathFullyQualified(cacheRoot)
+                ? Path.Combine(cacheRoot, cacheOptions.CacheFolder)
+                : Path.GetFullPath(Path.Combine(cacheRoot, cacheOptions.CacheFolder), contentRootPath);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -91,7 +91,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <param name="webRootPath">the webRootPath.</param>
         /// <param name="contentRootPath">the contentRootPath.</param>
         /// <returns>root path.</returns>
-        internal static string GetCacheRoot(in PhysicalFileSystemCacheOptions cacheOptions, in string webRootPath, in string contentRootPath)
+        internal static string GetCacheRoot(PhysicalFileSystemCacheOptions cacheOptions, string webRootPath, string contentRootPath)
         {
             var cacheRoot = string.IsNullOrEmpty(cacheOptions.CacheRoot)
                 ? webRootPath

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -72,7 +72,10 @@ namespace SixLabors.ImageSharp.Web.Caching
 
             // Allow configuration of the cache without having to register everything.
             this.cacheOptions = cacheOptions != null ? cacheOptions.Value : new PhysicalFileSystemCacheOptions();
-            this.cacheRootPath = Path.Combine(environment.WebRootPath, this.cacheOptions.CacheFolder);
+            var cacheRoot = string.IsNullOrEmpty(this.cacheOptions.CacheRoot)
+                ? environment.WebRootPath
+                : this.cacheOptions.CacheRoot;
+            this.cacheRootPath = Path.Combine(cacheRoot, this.cacheOptions.CacheFolder);
             if (!Directory.Exists(this.cacheRootPath))
             {
                 Directory.CreateDirectory(this.cacheRootPath);

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -72,10 +72,7 @@ namespace SixLabors.ImageSharp.Web.Caching
 
             // Allow configuration of the cache without having to register everything.
             this.cacheOptions = cacheOptions != null ? cacheOptions.Value : new PhysicalFileSystemCacheOptions();
-            var cacheRoot = string.IsNullOrEmpty(this.cacheOptions.CacheRoot)
-                ? environment.WebRootPath
-                : this.cacheOptions.CacheRoot;
-            this.cacheRootPath = Path.Combine(cacheRoot, this.cacheOptions.CacheFolder);
+            this.cacheRootPath = GetCacheRoot(this.cacheOptions, environment.WebRootPath);
             if (!Directory.Exists(this.cacheRootPath))
             {
                 Directory.CreateDirectory(this.cacheRootPath);
@@ -85,6 +82,20 @@ namespace SixLabors.ImageSharp.Web.Caching
             this.options = options.Value;
             this.cachedNameLength = (int)this.options.CachedNameLength;
             this.formatUtilities = formatUtilities;
+        }
+
+        /// <summary>
+        /// Determine the cache root path
+        /// </summary>
+        /// <param name="cacheOptions">the cache options.</param>
+        /// <param name="webRootPath">the webRootPath.</param>
+        /// <returns>root path.</returns>
+        internal static string GetCacheRoot(PhysicalFileSystemCacheOptions cacheOptions, string webRootPath)
+        {
+            var cacheRoot = string.IsNullOrEmpty(cacheOptions.CacheRoot)
+                ? webRootPath
+                : cacheOptions.CacheRoot;
+            return Path.Combine(cacheRoot, cacheOptions.CacheFolder);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
@@ -12,5 +12,10 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// Gets or sets the cache folder name.
         /// </summary>
         public string CacheFolder { get; set; } = "is-cache";
+
+        /// <summary>
+        /// Gets or sets the cache root folder.
+        /// </summary>
+        public string CacheRoot { get; set; }
     }
 }

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -21,27 +21,29 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public void CacheRootFromOptions()
+        [Theory]
+#if Linux
+        [InlineData("cacheFolder", "/Users/username", null, null, "/Users/username/cacheFolder")]
+        [InlineData("cacheFolder", null, "/Users/WebRoot", null, "/Users/WebRoot/cacheFolder")]
+        [InlineData("cacheFolder", "../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp/cacheFolder")]
+#elif OSX
+        [InlineData("cacheFolder", "/Users/username", null, null, "/Users/username/cacheFolder")]
+        [InlineData("cacheFolder", null, "/Users/WebRoot", null, "/Users/WebRoot/cacheFolder")]
+        [InlineData("cacheFolder", "../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp/cacheFolder")]
+#elif Windows
+        [InlineData("cacheFolder", "C:/Temp", null, null, "C:/Temp/cacheFolder")]
+        [InlineData("cacheFolder", null, "C:/WebRoot", null, "C:/WebRoot/cacheFolder")]
+        [InlineData("cacheFolder", "../Temp", null, "C:/this/a/root", "C:/this/a/Temp/cacheFolder")]
+#endif
+        public void CacheRootFromOptions(string cacheFolder, string cacheRoot, string webRootPath, string contentRootPath, string expected)
         {
             var cacheOptions = new PhysicalFileSystemCacheOptions();
-            cacheOptions.CacheFolder = "cacheFolder";
-            cacheOptions.CacheRoot = "C:\\Temp";
+            cacheOptions.CacheFolder = cacheFolder;
+            cacheOptions.CacheRoot = cacheRoot;
 
-            var cacheRoot = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, null);
+            var cacheRootResult = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, webRootPath, contentRootPath);
 
-            Assert.Equal(Path.Combine(cacheOptions.CacheRoot, cacheOptions.CacheFolder), cacheRoot);
-        }
-
-        [Fact]
-        public void CacheRootFromEnvironment()
-        {
-            var cacheOptions = new PhysicalFileSystemCacheOptions();
-            cacheOptions.CacheFolder = "cacheFolder";
-
-            var cacheRoot = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, "C:\\WebRoot");
-
-            Assert.Equal(Path.Combine("C:\\WebRoot", cacheOptions.CacheFolder), cacheRoot);
+            Assert.Equal(expected, cacheRootResult);
         }
     }
 }

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -31,9 +31,9 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
         [InlineData("cacheFolder", null, "/Users/WebRoot", null, "/Users/WebRoot/cacheFolder")]
         [InlineData("cacheFolder", "../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp/cacheFolder")]
 #elif Windows
-        [InlineData("cacheFolder", "C:/Temp", null, null, "C:/Temp/cacheFolder")]
-        [InlineData("cacheFolder", null, "C:/WebRoot", null, "C:/WebRoot/cacheFolder")]
-        [InlineData("cacheFolder", "../Temp", null, "C:/this/a/root", "C:/this/a/Temp/cacheFolder")]
+        [InlineData("cacheFolder", "C:/Temp", null, null, "C:\\Temp\\cacheFolder")]
+        [InlineData("cacheFolder", null, "C:/WebRoot", null, "C:\\WebRoot\\cacheFolder")]
+        [InlineData("cacheFolder", "../Temp", null, "C:/this/a/root", "C:\\this\\a\\Temp\\cacheFolder")]
 #endif
         public void CacheRootFromOptions(string cacheFolder, string cacheRoot, string webRootPath, string contentRootPath, string expected)
         {

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System.IO;
 using SixLabors.ImageSharp.Web.Caching;
 using Xunit;
 
@@ -18,6 +19,29 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
             string actual = PhysicalFileSystemCache.ToFilePath(Key, CachedNameLength);
 
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CacheRootFromOptions()
+        {
+            var cacheOptions = new PhysicalFileSystemCacheOptions();
+            cacheOptions.CacheFolder = "cacheFolder";
+            cacheOptions.CacheRoot = "C:\\Temp";
+
+            var cacheRoot = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, null);
+
+            Assert.Equal(Path.Combine(cacheOptions.CacheRoot, cacheOptions.CacheFolder), cacheRoot);
+        }
+
+        [Fact]
+        public void CacheRootFromEnvironment()
+        {
+            var cacheOptions = new PhysicalFileSystemCacheOptions();
+            cacheOptions.CacheFolder = "cacheFolder";
+
+            var cacheRoot = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, "C:\\WebRoot");
+
+            Assert.Equal(Path.Combine("C:\\WebRoot", cacheOptions.CacheFolder), cacheRoot);
         }
     }
 }

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -31,8 +31,8 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
         [InlineData("cacheFolder", null, "/Users/WebRoot", null, "/Users/WebRoot/cacheFolder")]
         [InlineData("cacheFolder", "../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp/cacheFolder")]
 #elif Windows
-        [InlineData("cacheFolder", "C:/Temp", null, null, "C:\\Temp\\cacheFolder")]
-        [InlineData("cacheFolder", null, "C:/WebRoot", null, "C:\\WebRoot\\cacheFolder")]
+        [InlineData("cacheFolder", "C:/Temp", null, null, "C:/Temp\\cacheFolder")]
+        [InlineData("cacheFolder", null, "C:/WebRoot", null, "C:/WebRoot\\cacheFolder")]
         [InlineData("cacheFolder", "../Temp", null, "C:/this/a/root", "C:\\this\\a\\Temp\\cacheFolder")]
 #endif
         public void CacheRootFromOptions(string cacheFolder, string cacheRoot, string webRootPath, string contentRootPath, string expected)

--- a/tests/ImageSharp.Web.Tests/ImageSharp.Web.Tests.csproj
+++ b/tests/ImageSharp.Web.Tests/ImageSharp.Web.Tests.csproj
@@ -8,6 +8,19 @@
 
     <!--Used to show test project to dotnet test-->
     <IsTestProject>true</IsTestProject>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsOSX)'=='true'">
+    <DefineConstants>OSX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsLinux)'=='true'">
+    <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Adding a new Option for the cache implementation. Now the CacheRoot can be set to an different folder than the webroot