### PR TITLE
Fix missing cache lookups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,373 +1,436 @@
-###############################################################################
-# EditorConfig is awesome: http://EditorConfig.org
-###############################################################################
+# Version: 1.6.2 (Using https://semver.org/)
+# Updated: 2020-11-02
+# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
+# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+# See http://EditorConfig.org for more information about .editorconfig files.
 
-###############################################################################
-# Top-most EditorConfig file
-###############################################################################
+##########################################
+# Common Settings
+##########################################
+
+# This file is the top-most EditorConfig file
 root = true
 
-###############################################################################
-# Set default behavior to:
-#   a UTF-8 encoding,
-#   Unix-style line endings,
-#   a newline ending the file,
-#   4 space indentation, and
-#   trimming of trailing whitespace
-###############################################################################
+# All Files
 [*]
 charset = utf-8
-end_of_line = lf
-insert_final_newline = true
 indent_style = space
 indent_size = 4
+end_of_line = lf
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-###############################################################################
-# Set file behavior to:
-#   2 space indentation
-###############################################################################
-[*.{cmd,config,csproj,json,props,ps1,resx,sh,targets}]
-indent_size = 2
+##########################################
+# File Extension Settings
+##########################################
 
-###############################################################################
-# Set file behavior to:
-#   Windows-style line endings, and
-#   tabular indentation
-###############################################################################
+# Visual Studio Solution Files
 [*.sln]
-end_of_line = crlf
 indent_style = tab
 
-###############################################################################
-# Set dotnet naming rules to:
-#    suggest async members be pascal case suffixed with Async
-#    suggest const declarations be pascal case
-#    suggest interfaces be pascal case prefixed with I
-#    suggest parameters be camel case
-#    suggest private and internal static fields be camel case
-#    suggest private and internal fields be camel case
-#    suggest public and protected declarations be pascal case
-#    suggest static readonly declarations be pascal case
-#    suggest type parameters be prefixed with T
-###############################################################################
-[*.cs]
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.severity = suggestion
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.style = pascal_case_suffixed_with_async
-dotnet_naming_rule.async_members_should_be_pascal_case_suffixed_with_async.symbols = async_members
+# Visual Studio XML Project Files
+[*.{csproj,vbproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
 
-dotnet_naming_rule.const_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.const_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.const_declarations_should_be_pascal_case.symbols = const_declarations
+# T4 Templates Files
+[*.{tt,ttinclude}]
+end_of_line = crlf
 
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.severity = suggestion
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.style = pascal_case_prefixed_with_i
-dotnet_naming_rule.interfaces_should_be_pascal_case_prefixed_with_i.symbols = interfaces
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
 
-dotnet_naming_rule.parameters_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.parameters_should_be_camel_case.style = camel_case
-dotnet_naming_rule.parameters_should_be_camel_case.symbols = parameters
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
 
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.style = camel_case
-dotnet_naming_rule.private_and_internal_static_fields_should_be_camel_case.symbols = private_and_internal_static_fields
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
 
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.style = camel_case
-dotnet_naming_rule.private_and_internal_fields_should_be_camel_case.symbols = private_and_internal_fields
+# Markdown Files
+[*.md]
+trim_trailing_whitespace = false
 
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.public_and_protected_declarations_should_be_pascal_case.symbols = public_and_protected_declarations
-dotnet_naming_symbols.public_and_protected_declarations.applicable_kinds = method, field, event, property
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,svg,vue}]
+indent_size = 2
 
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.style = pascal_case
-dotnet_naming_rule.static_readonly_declarations_should_be_pascal_case.symbols = static_readonly_declarations
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
 
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.severity = suggestion
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.style = pascal_case_prefixed_with_t
-dotnet_naming_rule.type_parameters_should_be_pascal_case_prefixed_with_t.symbols = type_parameters
+# Makefiles
+[Makefile]
+indent_style = tab
 
-###############################################################################
-# Set dotnet naming styles to define:
-#   camel case
-#   pascal case
-#   pascal case suffixed with Async
-#   pascal case prefixed with I
-#   pascal case prefixed with T
-###############################################################################
-[*.cs]
-dotnet_naming_style.camel_case.capitalization = camel_case
+##########################################
+# File Header (Uncomment to support file headers)
+# https://docs.microsoft.com/visualstudio/ide/reference/add-file-header
+##########################################
 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
+# [*.{cs,csx,cake,vb,vbx,tt,ttinclude}]
+file_header_template = Copyright (c) Six Labors.\nLicensed under the Apache License, Version 2.0.
 
-dotnet_naming_style.pascal_case_suffixed_with_async.capitalization = pascal_case
-dotnet_naming_style.pascal_case_suffixed_with_async.required_suffix = Async
+# SA1636: File header copyright text should match
+# Justification: .editorconfig supports file headers. If this is changed to a value other than "none", a stylecop.json file will need to added to the project.
+# dotnet_diagnostic.SA1636.severity = none
 
-dotnet_naming_style.pascal_case_prefixed_with_i.capitalization = pascal_case
-dotnet_naming_style.pascal_case_prefixed_with_i.required_prefix = I
+##########################################
+# .NET Language Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
+##########################################
 
-dotnet_naming_style.pascal_case_prefixed_with_t.capitalization = pascal_case
-dotnet_naming_style.pascal_case_prefixed_with_t.required_prefix = T
-
-###############################################################################
-# Set dotnet naming symbols to:
-#   async members
-#   const declarations
-#   interfaces
-#   private and internal fields
-#   private and internal static fields
-#   public and protected declarations
-#   static readonly declarations
-#   type parameters
-###############################################################################
-[*.cs]
-dotnet_naming_symbols.async_members.required_modifiers = async
-
-dotnet_naming_symbols.const_declarations.required_modifiers = const
-
-dotnet_naming_symbols.interfaces.applicable_kinds = interface
-
-dotnet_naming_symbols.parameters.applicable_kinds = parameter
-
-dotnet_naming_symbols.private_and_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_symbols.private_and_internal_fields.applicable_kinds = field
-
-dotnet_naming_symbols.private_and_internal_static_fields.applicable_accessibilities = private, internal
-dotnet_naming_symbols.private_and_internal_static_fields.applicable_kinds = field
-dotnet_naming_symbols.private_and_internal_static_fields.required_modifiers = static
-
-dotnet_naming_symbols.public_and_protected_declarations.applicable_accessibilities = public, protected
-
-dotnet_naming_symbols.static_readonly_declarations.required_modifiers = static, readonly
-
-dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
-
-###############################################################################
-# Set dotnet sort options to:
-#   do not separate import directives into groups, and
-#   sort system directives first
-###############################################################################
-[*.cs]
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = true
-
-###############################################################################
-# Set dotnet style options to:
-#   suggest null-coalescing expressions,
-#   suggest collection-initializers,
-#   suggest explicit tuple names,
-#   suggest null-propogation
-#   suggest object-initializers,
-#   generate parentheses in arithmetic binary operators for clarity,
-#   generate parentheses in other binary operators for clarity,
-#   don't generate parentheses in other operators if unnecessary,
-#   generate parentheses in relational binary operators for clarity,
-#   warn when not using predefined-types for locals, parameters, and members,
-#   generate predefined-types of type names for member access,
-#   generate auto properties,
-#   suggest compound assignment,
-#   generate conditional expression over assignment,
-#   generate conditional expression over return,
-#   suggest inferred anonymous types,
-#   suggest inferred tuple names,
-#   suggest 'is null' checks over '== null',
-#   don't generate 'this.' and 'Me.' for events,
-#   warn when not using 'this.' and 'Me.' for fields,
-#   warn when not using 'this.' and 'Me.' for methods,
-#   warn when not using 'this.' and 'Me.' for properties,
-#   suggest readonly fields, and
-#   generate accessibility modifiers for non interface members
-###############################################################################
-[*.cs]
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
-
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:silent
-
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-
-dotnet_style_qualification_for_event = false:silent
+# .NET Code Style Settings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#net-code-style-settings
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#this-and-me
 dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_method = true:warning
 dotnet_style_qualification_for_property = true:warning
+dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_event = true:warning
+# Language keywords instead of framework type names for type references
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#language-keywords
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+# Modifier preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#normalize-modifiers
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:warning
+dotnet_style_readonly_field = true:warning
+# Parentheses preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parentheses-preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+# Expression-level preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = false:suggestion
+dotnet_style_prefer_conditional_expression_over_return = false:suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+# Null-checking preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#null-checking-preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+# Parameter preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#parameter-preferences
+dotnet_code_quality_unused_parameters = all:warning
+# More style options (Undocumented)
+# https://github.com/MicrosoftDocs/visualstudio-docs/issues/3641
+dotnet_style_operator_placement_when_wrapping = end_of_line
+# https://github.com/dotnet/roslyn/pull/40070
+dotnet_style_prefer_simplified_interpolation = true:warning
 
-dotnet_style_readonly_field = true:suggestion
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-
-###############################################################################
-# Set dotnet style options to:
-#   suggest removing all unused parameters
-###############################################################################
-[*.cs]
-dotnet_code_quality_unused_parameters = all:suggestion
-
-###############################################################################
-# Set csharp indent options to:
-#   indent block contents,
-#   not indent braces,
-#   indent case contents,
-#   not indent case contents when block,
-#   indent labels one less than the current, and
-#   indent switch labels
-###############################################################################
-[*.cs]
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = false
-csharp_indent_labels = one_less_than_current
-csharp_indent_switch_labels = true
-
-###############################################################################
-# Set csharp new-line options to:
-#   insert a new-line before "catch",
-#   insert a new-line before "else",
-#   insert a new-line before "finally",
-#   insert a new-line before members in anonymous-types,
-#   insert a new-line before members in object-initializers, and
-#   insert a new-line before all open braces
-###############################################################################
-[*.cs]
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-
-csharp_new_line_before_open_brace = all
-
-###############################################################################
-# Set csharp preserve options to:
-#   preserve single-line blocks, and
-#   preserve single-line statements
-###############################################################################
-[*.cs]
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-
-###############################################################################
-# Set csharp space options to:
-#   remove any space after a cast,
-#   add a space after the colon in an inheritance clause,
-#   add a space after a comma,
-#   remove any space after a dot,
-#   add a space after keywords in control flow statements,
-#   add a space after a semicolon in a "for" statement,
-#   add a space before and after binary operators,
-#   remove space around declaration statements,
-#   add a space before the colon in an inheritance clause,
-#   remove any space before a comma,
-#   remove any space before a dot,
-#   remove any space before an open square-bracket,
-#   remove any space before a semicolon in a "for" statement,
-#   remove any space between empty square-brackets,
-#   remove any space between a method call's empty parameter list parenthesis,
-#   remove any space between a method call's name and its opening parenthesis,
-#   remove any space between a method call's parameter list parenthesis,
-#   remove any space between a method declaration's empty parameter list parenthesis,
-#   remove any space between a method declaration's name and its openening parenthesis,
-#   remove any space between a method declaration's parameter list parenthesis,
-#   remove any space between parentheses, and
-#   remove any space between square brackets
-###############################################################################
-[*.cs]
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
-
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_between_square_brackets = false
-
-###############################################################################
-# Set csharp style options to:
-#   generate braces,
-#   suggest simple default expressions,
-#   generate a preferred modifier order,
-#   suggest conditional delegate calls,
-#   suggest deconstructed variable declarations,
-#   generate expression-bodied accessors,
-#   generate expression-bodied constructors,
-#   generate expression-bodied indexers,
-#   generate expression-bodied lambdas,
-#   generate expression-bodied methods,
-#   generate expression-bodied operators,
-#   generate expression-bodied properties,
-#   suggest inlined variable declarations,
-#   suggest local over anonymous functions,
-#   suggest pattern-matching over "as" with "null" check,
-#   suggest pattern-matching over "is" with "cast" check,
-#   suggest throw expressions,
-#   generate a discard variable for unused value expression statements,
-#   suggest a discard variable for unused assignments,
-#   warn when using var for built-in types,
-#   warn when using var when the type is not apparent, and
-#   warn when not using var when the type is apparent
-#   warn when using simplified "using" declaration
-###############################################################################
-[*.cs]
-csharp_prefer_braces = true:silent
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
-
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_constructors = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_methods = true:silent
-csharp_style_expression_bodied_operators = true:silent
-csharp_style_expression_bodied_properties = true:silent
-
-csharp_style_inlined_variable_declaration = true:suggestion
-
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-
-csharp_style_throw_expression = true:suggestion
-
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-
+# C# Code Style Settings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings
+[*.{cs,csx,cake}]
+# Implicit and explicit types
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#implicit-and-explicit-types
 csharp_style_var_for_built_in_types = never
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = false:warning
+# Expression-bodied members
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-bodied-members
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_operators = true:warning
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+# Pattern matching
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#pattern-matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+# Inlined variable declarations
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#inlined-variable-declarations
+csharp_style_inlined_variable_declaration = true:warning
+# Expression-level preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#expression-level-preferences
+csharp_prefer_simple_default_expression = true:warning
+# "Null" checking preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-null-checking-preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+# Code block preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#code-block-preferences
+csharp_prefer_braces = true:warning
+# Unused value preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#unused-value-preferences
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+# Index and range preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+# Miscellaneous preferences
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_static_local_function = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
+
+##########################################
+# .NET Formatting Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
+##########################################
+
+# Organize usings
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#organize-using-directives
+dotnet_sort_system_directives_first = true
+# Newline options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#new-line-options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#indentation-options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+# Spacing options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#spacing-options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+# Wrapping options
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#wrap-options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+##########################################
+# .NET Naming Conventions
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-naming-conventions
+##########################################
+
+[*.{cs,csx,cake,vb,vbx}]
+
+##########################################
+# Styles
+##########################################
+
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization  = pascal_case
+dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
+dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
+# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
+dotnet_naming_style.internal_error_style.capitalization  = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+
+##########################################
+# .NET Design Guideline Field Naming Rules
+# Naming rules for fields follow the .NET Framework design guidelines
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
+##########################################
+
+# All public/protected/protected_internal constant fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols    = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All public/protected/protected_internal static readonly fields must be PascalCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols    = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No other public/protected/protected_internal fields are allowed
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds           = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols             = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style               = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity            = error
+
+##########################################
+# StyleCop Field Naming Rules
+# Naming rules for fields follow the StyleCop analyzers
+# This does not override any rules using disallowed_style above
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
+##########################################
+
+# All constant fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers         = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols    = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity   = warning
+
+# All static readonly fields must be PascalCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers         = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols    = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style      = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity   = warning
+
+# No non-private instance fields are allowed
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols               = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style                 = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity              = error
+
+# Private fields must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds           = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols     = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity    = warning
+
+# Local variables must be camelCase
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds           = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols     = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style       = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity    = silent
+
+# This rule should never fire.  However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds           = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols  = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style    = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+
+##########################################
+# Other Naming Rules
+##########################################
+
+# All of the following must be PascalCase:
+# - Namespaces
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Classes and Enumerations
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
+# - Delegates
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
+# - Constructors, Properties, Events, Methods
+#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols              = element_group
+dotnet_naming_rule.element_rule.style                = pascal_case_style
+dotnet_naming_rule.element_rule.severity             = warning
+
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols              = interface_group
+dotnet_naming_rule.interface_rule.style                = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity             = warning
+
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols              = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style                = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity             = warning
+
+# Function parameters use camelCase
+# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols              = parameters_group
+dotnet_naming_rule.parameters_rule.style                = camel_case_style
+dotnet_naming_rule.parameters_rule.severity             = warning
+
+##########################################
+# License
+##########################################
+# The following applies as to the .editorconfig file ONLY, and is
+# included below for reference, per the requirements of the license
+# corresponding to this .editorconfig file.
+# See: https://github.com/RehanSaeed/EditorConfig
+#
+# MIT License
+#
+# Copyright (c) 2017-2019 Muhammad Rehan Saeed
+# Copyright (c) 2019 Henry Gabryjelski
+#
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject
+# to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+##########################################

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 #   normalize to Unix-style line endings
 ###############################################################################
 *           text        eol=lf
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text and
@@ -54,7 +53,6 @@
 *.txt               text        eol=lf
 *.vb                text        eol=lf
 *.yml               text        eol=lf
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text
@@ -62,7 +60,6 @@
 #   diff as csharp
 ###############################################################################
 *.cs                text        eol=lf          diff=csharp
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text
@@ -74,7 +71,6 @@
 *.fsproj            text        eol=lf          merge=union
 *.ncrunchproject    text        eol=lf          merge=union
 *.vbproj            text        eol=lf          merge=union
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as text
@@ -82,37 +78,29 @@
 #   use a union merge when resoling conflicts
 ###############################################################################
 *.sln               text        eol=crlf        merge=union
-
 ###############################################################################
 # Set explicit file behavior to:
 #   treat as binary
 ###############################################################################
 *.basis             binary
-*.bmp               binary
-*.dds               binary
 *.dll               binary
 *.eot               binary
 *.exe               binary
-*.gif               binary
-*.jpg               binary
 *.ktx               binary
 *.otf               binary
 *.pbm               binary
 *.pdf               binary
-*.png               binary
 *.ppt               binary
 *.pptx              binary
 *.pvr               binary
 *.snk               binary
-*.tga               binary
 *.ttc               binary
 *.ttf               binary
-*.webp              binary
+*.wbmp              binary
 *.woff              binary
 *.woff2             binary
 *.xls               binary
 *.xlsx              binary
-
 ###############################################################################
 # Set explicit file behavior to:
 #   diff as plain text
@@ -124,3 +112,16 @@
 *.pptx              diff=astextplain
 *.rtf               diff=astextplain
 *.svg               diff=astextplain
+###############################################################################
+# Handle image files by git lfs
+###############################################################################
+*.jpg               filter=lfs diff=lfs merge=lfs -text
+*.jpeg              filter=lfs diff=lfs merge=lfs -text
+*.bmp               filter=lfs diff=lfs merge=lfs -text
+*.gif               filter=lfs diff=lfs merge=lfs -text
+*.png               filter=lfs diff=lfs merge=lfs -text
+*.tif               filter=lfs diff=lfs merge=lfs -text
+*.tiff              filter=lfs diff=lfs merge=lfs -text
+*.tga               filter=lfs diff=lfs merge=lfs -text
+*.webp              filter=lfs diff=lfs merge=lfs -text
+*.dds               filter=lfs diff=lfs merge=lfs -text

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,100 +10,12 @@
     that is done by the file that imports us.
   -->
 
-  <!-- Default settings that are used by other settings -->
   <PropertyGroup>
-    <BaseArtifactsPath>$(MSBuildThisFileDirectory)artifacts/</BaseArtifactsPath>
-    <BaseArtifactsPathSuffix>$(SixLaborsProjectCategory)/$(MSBuildProjectName)</BaseArtifactsPathSuffix>
-    <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/SixLabors/ImageSharp.Web/</RepositoryUrl>
+    <!-- This MUST be defined before importing props. -->
+    <SixLaborsSolutionDirectory>$(MSBuildThisFileDirectory)</SixLaborsSolutionDirectory>
   </PropertyGroup>
 
-  <!-- Default settings that explicitly differ from the Sdk.props defaults  -->
-  <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseIntermediateOutputPath>$(BaseArtifactsPath)obj/$(BaseArtifactsPathSuffix)/</BaseIntermediateOutputPath>
-    <DebugType>portable</DebugType>
-    <DebugType Condition="'$(codecov)' != ''">full</DebugType>
-    <NullableContextOptions>disable</NullableContextOptions>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-  </PropertyGroup>
-
-  <!--
-    https://apisof.net/
-    +===================+=======+==========+=====================+=============+=================+====================+==============+
-    | SUPPORTS          | MATHF | HASHCODE | EXTENDED_INTRINSICS | SPAN_STREAM | ENCODING_STRING | RUNTIME_INTRINSICS | CODECOVERAGE |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+
-    | netcoreapp3.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        Y           |      Y       |
-    | netcoreapp2.1     |   Y   |    Y     |         Y           |      Y      |        Y        |        N           |      Y       |
-    +===================+=======+==========+=====================+=============+=================+====================+==============+
-    -->
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_RUNTIME_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <DefineConstants>$(DefineConstants);SUPPORTS_MATHF</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HASHCODE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_EXTENDED_INTRINSICS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_STREAM</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENCODING_STRING</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_CODECOVERAGE</DefineConstants>
-  </PropertyGroup>
-
-  <!-- Default settings that explicitly differ from the Sdk.targets defaults-->
-  <PropertyGroup>
-    <Authors>Six Labors and contributors</Authors>
-    <BaseOutputPath>$(BaseArtifactsPath)bin/$(BaseArtifactsPathSuffix)/</BaseOutputPath>
-    <Company>Six Labors</Company>
-    <PackageOutputPath>$(BaseArtifactsPath)pkg/$(BaseArtifactsPathSuffix)/$(Configuration)/</PackageOutputPath>
-    <Product>SixLabors.ImageSharp.Web</Product>
-    <VersionPrefix>0.0.1</VersionPrefix>
-    <VersionPrefix Condition="'$(packageversion)' != ''">$(PackageVersion)</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
-  </PropertyGroup>
-
-  <!--MinVer Properties for versioning-->
-  <PropertyGroup>
-    <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerVerbosity>normal</MinVerVerbosity>
-  </PropertyGroup>
-  
-  <!-- Default settings that are otherwise undefined -->
-  <PropertyGroup>
-    <Copyright>Copyright © Six Labors</Copyright>
-    <Features>strict;IOperation</Features>
-    <HighEntropyVA>true</HighEntropyVA>
-    <LangVersion>8.0</LangVersion>
-    <NeutralLanguage>en</NeutralLanguage>
-    <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>
-    <PackageIcon>sixlabors.imagesharp.web.128.png</PackageIcon>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <RepositoryType>git</RepositoryType>
-    <RestoreSources>
-      https://www.myget.org/F/sixlabors/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)shared-infrastructure/SixLabors.snk</AssemblyOriginatorKeyFile>
-    <SixLaborsPublicKey>00240000048000009400000006020000002400005253413100040000010001000147e6fe6766715eec6cfed61f1e7dcdbf69748a3e355c67e9d8dfd953acab1d5e012ba34b23308166fdc61ee1d0390d5f36d814a6091dd4b5ed9eda5a26afced924c683b4bfb4b3d64b0586a57eff9f02b1f84e3cb0ddd518bd1697f2c84dcbb97eb8bb5c7801be12112ed0ec86db934b0e9a5171e6bb1384b6d2f7d54dfa97</SixLaborsPublicKey>
-    <UseSharedCompilation>true</UseSharedCompilation>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-
-  <!-- Package references and additional files which are consumed by all projects -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" IsImplicitlyDefined="true" PrivateAssets="All"/>
-    <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)shared-infrastructure\stylecop.json" />
-    <!--NuGet package icon source-->
-    <None Include="$(MSBuildThisFileDirectory)shared-infrastructure\branding\icons\imagesharp.web\sixlabors.imagesharp.web.128.png" Pack="true" PackagePath="" />
-  </ItemGroup>
+  <!-- Import the shared global .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\props\SixLabors.Global.props" />
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,42 +5,12 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have been
+    instead. They import fairly late and most other props/targets will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <!-- Settings that append the existing setting value -->
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);$(OS)</DefineConstants>
-  </PropertyGroup>
+  <!-- Import the shared global .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)shared-infrastructure\msbuild\targets\SixLabors.Global.targets"/>
 
-  <!-- Package versions for package references across all projects -->
-  <ItemGroup>
-    <!--Global Dependencies-->
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.3.1" />
-    <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
-
-    <!--Src Dependencies-->
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.4.0" />
-    <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
-    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Update="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Update="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
-    <PackageReference Update="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
-    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0"/>
-  </ItemGroup>
-  
 </Project>

--- a/before.ImageSharp.Web.sln.targets
+++ b/before.ImageSharp.Web.sln.targets
@@ -9,7 +9,7 @@ See https://t.co/0A4WzeGMZS
     <ItemGroup>
       <ProjectReference
         Remove="$(MSBuildThisFileDirectory)samples\ImageSharp.Web.Sample\ImageSharp.Web.Sample.csproj"
-        Condition="'$(GITHUB_ACTIONS)' == 'true'"/>
+        Condition="'$(CI)' == 'true'"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -5,27 +5,19 @@
     Directory.Build.props is automatically picked up and imported by
     Microsoft.Common.props. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly early and only Sdk.props will have been
+    instead. They import fairly early and only Sdk.props will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
     <SixLaborsProjectCategory>samples</SixLaborsProjectCategory>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>$(NoWarn);</NoWarn>
-  </PropertyGroup>
-
+  <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
-  
+
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -5,15 +5,12 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have
+    instead. They import fairly late and most other props/targets will have
     been imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.targets</MSBuildAllProjects>
-  </PropertyGroup>
-
+  <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,45 +5,27 @@
     Directory.Build.props is automatically picked up and imported by
     Microsoft.Common.props. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly early and only Sdk.props will have been
+    instead. They import fairly early and only Sdk.props will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
-    <SixLaborsProjectCategory>src</SixLaborsProjectCategory>
-  </PropertyGroup>
+  <!-- Import the shared src .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\props\SixLabors.Src.props" />
 
+  <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.ruleset</CodeAnalysisRuleSet>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-
+  <!-- Compilation properties. -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <!--Add deterministic builds in CI-->
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  
   <ItemGroup>
     <!-- DynamicProxyGenAssembly2 is needed so Moq can use our internals -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
-    <InternalsVisibleTo Include="SixLabors.ImageSharp.Web.Tests"  Key="$(SixLaborsPublicKey)" />
-    <InternalsVisibleTo Include="ImageSharp.Web.Benchmarks"  Key="$(SixLaborsPublicKey)" />
+    <InternalsVisibleTo Include="ImageSharp.Web.Benchmarks" Key="$(SixLaborsPublicKey)" />
+    <InternalsVisibleTo Include="SixLabors.ImageSharp.Web.Tests" Key="$(SixLaborsPublicKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,74 +5,36 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have
+    instead. They import fairly late and most other props/targets will have
     been imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.targets</MSBuildAllProjects>
-  </PropertyGroup>
+  <!-- Import the shared src .targets file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\targets\SixLabors.Src.targets" />
 
+  <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
-  <PropertyGroup>
-    <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
-  </PropertyGroup>
-
-  <!-- Workaround for running Coverlet with Deterministic builds -->
-  <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
-  <Target Name="CoverletGetPathMap"
-            DependsOnTargets="InitializeSourceRootMappedPaths"
-            Returns="@(_LocalTopLevelSourceRoot)"
-            Condition="'$(DeterministicSourcePaths)' == 'true'">
-    <ItemGroup>
-      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
-    </ItemGroup>
-  </Target>
-  
-  <ItemDefinitionGroup>
-    <InternalsVisibleTo>
-      <Visible>false</Visible>
-    </InternalsVisibleTo>
-  </ItemDefinitionGroup>
-
-  <Target Name="GenerateInternalsVisibleTo"
-          BeforeTargets="CoreCompile"
-          DependsOnTargets="PrepareForBuild;CoreGenerateInternalsVisibleTo"
-          Condition="'@(InternalsVisibleTo)' != ''" />
-
-  <Target Name="CoreGenerateInternalsVisibleTo"
-          Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(GeneratedInternalsVisibleToFile)">
-    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)" Condition="'%(InternalsVisibleTo.Key)' == ''">
-      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
-    </CreateItem>
-    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)" Condition="'%(InternalsVisibleTo.Key)' != ''">
-      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
-    </CreateItem>
-
-    <WriteCodeFragment AssemblyAttributes="@(InternalsVisibleToAttribute)" Language="$(Language)" OutputFile="$(GeneratedInternalsVisibleToFile)">
-      <Output TaskParameter="OutputFile" ItemName="Compile" />
-      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
-    </WriteCodeFragment>
-  </Target>
-
-  <!-- Empty target so that `dotnet test` will work on the solution -->
-  <!-- https://github.com/Microsoft/vstest/issues/411 -->
-  <Target Name="VSTest" Condition="'$(IsTestProject)' == 'true'"/>
-
   <ItemGroup>
-    <!--Shared config files that have to exist at root level.-->
-    <ConfigFilesToCopy Include="..\..\shared-infrastructure\.editorconfig;..\..\shared-infrastructure\.gitattributes" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.4.0" />
+    <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
 
-  <!--Ensures our config files are up to date.-->
-  <Target Name="CopyFiles" BeforeTargets="Build">
-    <Copy SourceFiles="@(ConfigFilesToCopy)"
-          SkipUnchangedFiles = "true"
-          DestinationFolder="..\..\" />
-  </Target>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Update="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Update="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0"/>
+  </ItemGroup>
 </Project>

--- a/src/ImageSharp.Web.Providers.Azure/ImageSharp.Web.Providers.Azure.csproj
+++ b/src/ImageSharp.Web.Providers.Azure/ImageSharp.Web.Providers.Azure.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
-    <PackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -27,8 +27,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
-    <PackageReference Include="MinVer" PrivateAssets="All" />
     <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -418,7 +418,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                                         {
                                             metadata = await resolver.GetMetaDataAsync();
                                         }
-                                        
+
                                         return (resolver, metadata);
                                     });
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -410,7 +410,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                             (IImageCacheResolver, ImageCacheMetadata) cachedImageResolver = await
                                 CacheResolverLru.GetOrAddAsync(
                                     key,
-                                    async k => 
+                                    async k =>
                                     {
                                         var resolver = await this.cache.GetAsync(k);
                                         ImageCacheMetadata metadata = default;
@@ -418,6 +418,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                                         {
                                             metadata = await resolver.GetMetaDataAsync();
                                         }
+                                        
                                         return (resolver, metadata);
                                     });
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -412,7 +412,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                                     key,
                                     async k =>
                                     {
-                                        var resolver = await this.cache.GetAsync(k);
+                                        IImageCacheResolver resolver = await this.cache.GetAsync(k);
                                         ImageCacheMetadata metadata = default;
                                         if (resolver != null)
                                         {

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,36 +5,20 @@
     Directory.Build.props is automatically picked up and imported by
     Microsoft.Common.props. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly early and only Sdk.props will have been
+    instead. They import fairly early and only Sdk.props will have been
     imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.props</MSBuildAllProjects>
-    <SixLaborsProjectCategory>tests</SixLaborsProjectCategory>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+  <!-- Import the shared tests .props file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\props\SixLabors.Tests.props" />
 
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\shared-infrastructure\SixLabors.Tests.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>$(NoWarn);</NoWarn>
-  </PropertyGroup>
-
+  <!-- Import the solution .props file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" IsImplicitlyDefined="true" />
-    <PackageReference Include="xunit" IsImplicitlyDefined="true" />
-    <PackageReference Include="xunit.runner.visualstudio" IsImplicitlyDefined="true" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\ImageSharp.Web.Providers.Azure\ImageSharp.Web.Providers.Azure.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\ImageSharp.Web\ImageSharp.Web.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(codecov)' == 'true' AND '$(IsTestProject)' == 'true'">
-    <PackageReference Include="coverlet.collector" IsImplicitlyDefined="true" />
-  </ItemGroup>
-  
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -5,36 +5,23 @@
     Directory.Build.targets is automatically picked up and imported by
     Microsoft.Common.targets. This file needs to exist, even if empty so that
     files in the parent directory tree, with the same name, are not imported
-    instead. The import fairly late and most other props/targets will have
+    instead. They import fairly late and most other props/targets will have
     been imported beforehand. We also don't need to add ourselves to
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileDirectory)..\Directory.Build.targets</MSBuildAllProjects>
-  </PropertyGroup>
+  <!-- Import the shared tests .targets file -->
+  <Import Project="$(MSBuildThisFileDirectory)..\shared-infrastructure\msbuild\targets\SixLabors.Tests.targets" />
 
+  <!-- Import the solution .targets file. -->
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
-  <!-- Tool versions for tool references across all projects -->
+  <!-- Test Dependencies -->
   <ItemGroup>
-    <!--dotnet tools does not have an x86 runner. You have to use separate SDKs-->
-    <!--https://github.com/actions/setup-dotnet/issues/72-->
-    <DotNetCliToolReference Update="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--Test Dependencies-->
-    <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.4.0" />
+    <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.4" />
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="11.1.2" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200116-01" />
-
-    <!--Don't update these. We're getting AmbiguousMatchException on Linux-->
-    <!--See https://github.com/xunit/xunit/issues/1771-->
-    <PackageReference Update="xunit" Version="2.3.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -22,6 +22,14 @@
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.4" />
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="11.1.2" />
+
+    <!--
+        Don't update these. We're getting AmbiguousMatchException for
+        CommandParser tests.
+    -->
+    <!--See https://github.com/xunit/xunit/issues/1771-->
+    <PackageReference Update="xunit" Version="2.3.1" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/tests/ImageSharp.Web.Benchmarks/MemoryConfig.cs
+++ b/tests/ImageSharp.Web.Benchmarks/MemoryConfig.cs
@@ -8,9 +8,6 @@ namespace SixLabors.ImageSharp.Web.Benchmarks
 {
     public class MemoryConfig : ManualConfig
     {
-        public MemoryConfig()
-        {
-            this.Add(MemoryDiagnoser.Default);
-        }
+        public MemoryConfig() => this.AddDiagnoser(MemoryDiagnoser.Default);
     }
 }

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -22,24 +22,26 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
         }
 
         [Theory]
-#if Linux
+#if OS_LINUX
         [InlineData("cacheFolder", "/Users/username", null, null, "/Users/username/cacheFolder")]
         [InlineData("cacheFolder", null, "/Users/WebRoot", null, "/Users/WebRoot/cacheFolder")]
         [InlineData("cacheFolder", "../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp/cacheFolder")]
-#elif OSX
+#elif OS_OSX
         [InlineData("cacheFolder", "/Users/username", null, null, "/Users/username/cacheFolder")]
         [InlineData("cacheFolder", null, "/Users/WebRoot", null, "/Users/WebRoot/cacheFolder")]
         [InlineData("cacheFolder", "../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp/cacheFolder")]
-#elif Windows
+#elif OS_WINDOWS
         [InlineData("cacheFolder", "C:/Temp", null, null, "C:/Temp\\cacheFolder")]
         [InlineData("cacheFolder", null, "C:/WebRoot", null, "C:/WebRoot\\cacheFolder")]
         [InlineData("cacheFolder", "../Temp", null, "C:/this/a/root", "C:\\this\\a\\Temp\\cacheFolder")]
 #endif
         public void CacheRootFromOptions(string cacheFolder, string cacheRoot, string webRootPath, string contentRootPath, string expected)
         {
-            var cacheOptions = new PhysicalFileSystemCacheOptions();
-            cacheOptions.CacheFolder = cacheFolder;
-            cacheOptions.CacheRoot = cacheRoot;
+            var cacheOptions = new PhysicalFileSystemCacheOptions
+            {
+                CacheFolder = cacheFolder,
+                CacheRoot = cacheRoot
+            };
 
             var cacheRootResult = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, webRootPath, contentRootPath);
 

--- a/tests/ImageSharp.Web.Tests/Commands/CommandParserTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/CommandParserTests.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
         private static readonly string PiStringDk = Pi.ToString(Dk);
         private static readonly double RoundedPi = Math.Round(Pi, MidpointRounding.AwayFromZero);
 
-        public static TheoryData<object, string, CultureInfo> IntegralValuesInv
+        public static TheoryData<object, string, CultureInfo> IntegralValuesInv { get; }
             = new TheoryData<object, string, CultureInfo>
         {
             { (sbyte)1, "1", Inv },
@@ -38,7 +38,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
             { 1M, "1", Inv },
         };
 
-        public static TheoryData<object, string, CultureInfo> IntegralValuesDk
+        public static TheoryData<object, string, CultureInfo> IntegralValuesDk { get; }
             = new TheoryData<object, string, CultureInfo>
         {
                     { (sbyte)1, "1", Dk },
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
                     { 1M, "1", Dk },
         };
 
-        public static TheoryData<object, string, CultureInfo> RealValuesInv
+        public static TheoryData<object, string, CultureInfo> RealValuesInv { get; }
             = new TheoryData<object, string, CultureInfo>
         {
             { (sbyte)RoundedPi, PiStringInv, Inv },
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
             { (decimal)Pi, PiStringInv, Inv },
         };
 
-        public static TheoryData<object, string, CultureInfo> RealValuesDanish
+        public static TheoryData<object, string, CultureInfo> RealValuesDanish { get; }
             = new TheoryData<object, string, CultureInfo>
         {
             { (sbyte)RoundedPi, PiStringDk, Dk },
@@ -86,44 +86,44 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
             { (decimal)Pi, PiStringDk, Dk },
         };
 
-        public static TheoryData<ResizeMode, string, CultureInfo> EnumValues
+        public static TheoryData<ResizeMode, string, CultureInfo> EnumValues { get; }
             = new TheoryData<ResizeMode, string, CultureInfo>
         {
             { ResizeMode.Max, "max", Inv },
             { ResizeMode.Crop, "this is not, an enum value", Inv }, // Unknown returns default
         };
 
-        public static TheoryData<int[], string, CultureInfo> IntegralArrays
+        public static TheoryData<int[], string, CultureInfo> IntegralArrays { get; }
             = new TheoryData<int[], string, CultureInfo>
         {
             { new[] { 1, 2, 3, 4 }, ToNumericList(Inv, 1, 2, 3, 4), Inv },
         };
 
-        public static TheoryData<float[], string, CultureInfo> RealArraysInv
+        public static TheoryData<float[], string, CultureInfo> RealArraysInv { get; }
             = new TheoryData<float[], string, CultureInfo>
         {
             { new[] { 1.667F, 2.667F, 3.667F, 4.667F }, ToNumericList(Inv, 1.667F, 2.667F, 3.667F, 4.667F), Inv },
         };
 
-        public static TheoryData<float[], string, CultureInfo> RealArraysDk
+        public static TheoryData<float[], string, CultureInfo> RealArraysDk { get; }
             = new TheoryData<float[], string, CultureInfo>
         {
             { new[] { 1.667F, 2.667F, 3.667F, 4.667F }, ToNumericList(Dk, 1.667F, 2.667F, 3.667F, 4.667F), Dk },
         };
 
-        public static TheoryData<object, string, CultureInfo> IntegralLists
+        public static TheoryData<object, string, CultureInfo> IntegralLists { get; }
             = new TheoryData<object, string, CultureInfo>
         {
             { new List<int> { 1, 2, 3, 4 }, ToNumericList(Inv, 1, 2, 3, 4), Inv },
         };
 
-        public static TheoryData<List<float>, string, CultureInfo> RealLists
+        public static TheoryData<List<float>, string, CultureInfo> RealLists { get; }
             = new TheoryData<List<float>, string, CultureInfo>
         {
             { new List<float> { 1.667F, 2.667F, 3.667F, 4.667F }, "1.667,2.667,3.667,4.667", Inv },
         };
 
-        public static TheoryData<Color, string, CultureInfo> ColorValuesInv
+        public static TheoryData<Color, string, CultureInfo> ColorValuesInv { get; }
             = new TheoryData<Color, string, CultureInfo>
         {
             { default, string.Empty, Inv },
@@ -135,7 +135,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
             { Color.YellowGreen, "9ACD32FF", Inv },
         };
 
-        public static TheoryData<Color, string, CultureInfo> ColorValuesDk
+        public static TheoryData<Color, string, CultureInfo> ColorValuesDk { get; }
             = new TheoryData<Color, string, CultureInfo>
         {
             { default, string.Empty, Dk },

--- a/tests/ImageSharp.Web.Tests/ImageSharp.Web.Tests.csproj
+++ b/tests/ImageSharp.Web.Tests/ImageSharp.Web.Tests.csproj
@@ -1,26 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>SixLabors.ImageSharp.Web.Tests</RootNamespace>
     <AssemblyName>SixLabors.ImageSharp.Web.Tests</AssemblyName>
-
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
-
-    <!--Used to show test project to dotnet test-->
-    <IsTestProject>true</IsTestProject>
-    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(IsWindows)'=='true'">
-    <DefineConstants>Windows</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsOSX)'=='true'">
-    <DefineConstants>OSX</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(IsLinux)'=='true'">
-    <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,11 +17,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Http" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\ImageSharp.Web.Providers.Azure\ImageSharp.Web.Providers.Azure.csproj" />
-    <ProjectReference Include="..\..\src\ImageSharp.Web\ImageSharp.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes https://github.com/SixLabors/ImageSharp.Web/issues/140

Simple option. 

Merge them into one cache, and treat them as tuples.

Other option is to cache it locally inside `IImageCacheResolver` so that subsequent calls retrieve the same instance.

But I think this involves less changes.


