### PR TITLE
Adapting log level when files are not found

### DIFF
--- a/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
+++ b/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
@@ -23,12 +23,12 @@ namespace SixLabors.ImageSharp.Web.Middleware
         static LoggerExtensions()
         {
             LogProcessingErrorAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Error,
+                logLevel: LogLevel.Debug,
                 eventId: 1,
                 formatString: "The image '{Uri}' could not be processed");
 
             LogResolveFailedAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Error,
+                logLevel: LogLevel.Debug,
                 eventId: 2,
                 formatString: "The image '{Uri}' could not be resolved");
 


### PR DESCRIPTION
Fixes #143

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Error is too intrusive and these events are too common, the event log can then fill up quickly. Moving it to `Debug` since this is what aspnet uses for the standard static file provider on these events.