### PR TITLE
Obsolete SetMemoryAllocator builder extensions

### DIFF
--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -65,7 +65,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         /// <param name="builder">The core builder.</param>
         /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
         [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.")]
-        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder) 
+        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder)
             where TMemoryAllocator : MemoryAllocator
             => builder;
 

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -65,7 +65,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         /// <param name="builder">The core builder.</param>
         /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
         [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.")]
-        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder) where TMemoryAllocator : MemoryAllocator
+        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder) 
+            where TMemoryAllocator : MemoryAllocator
             => builder;
 
         /// <summary>

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -54,12 +54,9 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         /// <param name="builder">The core builder.</param>
         /// <param name="implementationFactory">The factory method for returning a <see cref="MemoryAllocator"/>.</param>
         /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
+        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.")]
         public static IImageSharpBuilder SetMemoryAllocator(this IImageSharpBuilder builder, Func<IServiceProvider, MemoryAllocator> implementationFactory)
-        {
-            var descriptor = new ServiceDescriptor(typeof(MemoryAllocator), implementationFactory, ServiceLifetime.Singleton);
-            builder.Services.Replace(descriptor);
-            return builder;
-        }
+            => builder;
 
         /// <summary>
         /// Sets the given <see cref="MemoryAllocator"/> adding it to the service collection.
@@ -67,13 +64,9 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         /// <typeparam name="TMemoryAllocator">The type of class implementing <see cref="MemoryAllocator"/>to add.</typeparam>
         /// <param name="builder">The core builder.</param>
         /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
-        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder)
-            where TMemoryAllocator : MemoryAllocator
-        {
-            var descriptor = new ServiceDescriptor(typeof(MemoryAllocator), typeof(TMemoryAllocator), ServiceLifetime.Singleton);
-            builder.Services.Replace(descriptor);
-            return builder;
-        }
+        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.")]
+        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder) where TMemoryAllocator : MemoryAllocator
+            => builder;
 
         /// <summary>
         /// Sets the given <see cref="IImageCache"/> adding it to the service collection.

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         /// <param name="builder">The core builder.</param>
         /// <param name="implementationFactory">The factory method for returning a <see cref="MemoryAllocator"/>.</param>
         /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
-        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.")]
+        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.", true)]
         public static IImageSharpBuilder SetMemoryAllocator(this IImageSharpBuilder builder, Func<IServiceProvider, MemoryAllocator> implementationFactory)
             => builder;
 
@@ -64,7 +64,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         /// <typeparam name="TMemoryAllocator">The type of class implementing <see cref="MemoryAllocator"/>to add.</typeparam>
         /// <param name="builder">The core builder.</param>
         /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
-        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.")]
+        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.", true)]
         public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder)
             where TMemoryAllocator : MemoryAllocator
             => builder;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Obsoletes `SetMemoryAllocator` (from https://github.com/SixLabors/ImageSharp.Web/discussions/152) - that's caused me confusion in the past before too :)

I was going to remove the comments, but then stylecop doesn't like it. 

Could update them to mention the obsolete message if preferable?

Could also just remove them, instead of obsolete... 