### PR TITLE
Reduce allocations in ImageSharpMiddleware.Invoke for common case

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -185,16 +184,24 @@ namespace SixLabors.ImageSharp.Web.Middleware
         public async Task Invoke(HttpContext context)
 #pragma warning restore IDE1006 // Naming Styles
         {
-            IDictionary<string, string> commands = this.requestParser.ParseRequestCommands(context);
+            // We expect to get concrete collection type which removes virtual dispatch concerns and enumerator allocations
+            IDictionary<string, string> parsedCommands = this.requestParser.ParseRequestCommands(context);
+            Dictionary<string, string> commands = parsedCommands as Dictionary<string, string> ?? new Dictionary<string, string>(parsedCommands, StringComparer.OrdinalIgnoreCase);
+
             if (commands.Count > 0)
             {
-                // Strip out any unknown commands.
-                foreach (string command in new List<string>(commands.Keys))
+                // Strip out any unknown commands, if needed.
+                int index = 0;
+                foreach (string command in commands.Keys)
                 {
                     if (!this.knownCommands.Contains(command))
                     {
-                        commands.Remove(command);
+                        // Need to actually remove, allocates new list to allow modifications
+                        this.StripUnknownCommands(commands, startAtIndex: index);
+                        break;
                     }
+
+                    ++index;
                 }
             }
 
@@ -237,6 +244,19 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 sourceImageResolver,
                 new ImageContext(context, this.options),
                 commands);
+        }
+
+        private void StripUnknownCommands(Dictionary<string, string> commands, int startAtIndex)
+        {
+            var keys = new List<string>(commands.Keys);
+            for (var index = startAtIndex; index < keys.Count; index++)
+            {
+                string command = keys[index];
+                if (!this.knownCommands.Contains(command))
+                {
+                    commands.Remove(command);
+                }
+            }
         }
 
         private async Task ProcessRequestAsync(

--- a/tests/ImageSharp.Web.Tests/Commands/PresetOnlyQueryCollectionRequestParserTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/PresetOnlyQueryCollectionRequestParserTests.cs
@@ -54,7 +54,6 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
             Assert.Equal(expected, actual);
         }
 
-
         [Fact]
         public void PresetOnlyQueryCollectionRequestParserCommandsWithoutPresetParam()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description

Remove virtual dispatch and enumeration allocations for common path in `ImageSharpMiddleware.Invoke `when all parameters are known commands. We know that dictionary should be of concrete type in known implementations so casting to concrete to remove virtual dispatch and enumerator allocations.

No hard feelings if PR closed as non-issue, just demonstrating something I profiled in Orchard, commands are known.