### PR TITLE
Update References

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,8 +17,8 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.targets" />
 
   <ItemGroup>
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.4.0" />
-    <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
     <PackageReference Update="SixLabors.ImageSharp" Version="1.0.4" />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -18,8 +18,8 @@
 
   <!-- Test Dependencies -->
   <ItemGroup>
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.4.0" />
-    <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.4" />
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="11.1.2" />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

With the Release of .net 6.0 around the corner, I thought it would be a good idea to update to ImageSharp 1.0.4 for the fix of [Issue1704](https://github.com/SixLabors/ImageSharp/issues/1704).

While I was at it, i also update some external references to newer versions.