### PR TITLE
Avoid most allocations in GetExtensionFromUri

### DIFF
--- a/src/ImageSharp.Web/FormatUtilities.cs
+++ b/src/ImageSharp.Web/FormatUtilities.cs
@@ -65,19 +65,11 @@ namespace SixLabors.ImageSharp.Web
                     return ext;
                 }
 
-#if !NETCOREAPP3_1_OR_GREATER
-                path = uri.ToLowerInvariant().AsSpan(0, query);
-#else
                 path = uri.AsSpan(0, query);
-#endif
             }
             else
             {
-#if !NETCOREAPP3_1_OR_GREATER
-                path = uri.ToLowerInvariant();
-#else
                 path = uri;
-#endif
             }
 
             int extensionIndex;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Avoid some of the string allocations in GetExtensionFromUri, and it's also faster.

| Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|
|    Old | 74.75 us | 0.813 us | 0.761 us |  1.00 |    0.00 | 2.0752 |     18 KB |
|    New | 60.40 us | 1.139 us | 1.119 us |  0.81 |    0.02 | 1.2207 |     11 KB |
|    NewV2 | 57.30 us | 0.905 us | 0.846 us |  0.77 | 0.02 | 0.9766 |      8 KB |
|    NewV3 | 56.38 us | 0.348 us | 0.325 us |  0.77 | 0.02 |  0.3662 |      3 KB |
<!-- Thanks for contributing to ImageSharp! -->
