### PR TITLE
LogServedAction+ changed to Debug rather than Info

### DIFF
--- a/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
+++ b/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 formatString: "The image '{Uri}' was not modified");
 
             LogPreconditionFailedAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Debug,
+                logLevel: LogLevel.Warning,
                 eventId: 5,
                 formatString: "Precondition for image '{Uri}' failed");
         }

--- a/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
+++ b/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
@@ -33,17 +33,17 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 formatString: "The image '{Uri}' could not be resolved");
 
             LogServedAction = LoggerMessage.Define<string, string>(
-                logLevel: LogLevel.Information,
+                logLevel: LogLevel.Debug,
                 eventId: 3,
                 formatString: "Sending image. Request uri: '{Uri}'. Cached Key: '{Key}'");
 
             LogPathNotModifiedAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Information,
+                logLevel: LogLevel.Debug,
                 eventId: 4,
                 formatString: "The image '{Uri}' was not modified");
 
             LogPreconditionFailedAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Information,
+                logLevel: LogLevel.Debug,
                 eventId: 5,
                 formatString: "Precondition for image '{Uri}' failed");
         }

--- a/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
+++ b/src/ImageSharp.Web/Middleware/LoggerExtensions.cs
@@ -23,12 +23,12 @@ namespace SixLabors.ImageSharp.Web.Middleware
         static LoggerExtensions()
         {
             LogProcessingErrorAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Debug,
+                logLevel: LogLevel.Error,
                 eventId: 1,
                 formatString: "The image '{Uri}' could not be processed");
 
             LogResolveFailedAction = LoggerMessage.Define<string>(
-                logLevel: LogLevel.Debug,
+                logLevel: LogLevel.Warning,
                 eventId: 2,
                 formatString: "The image '{Uri}' could not be resolved");
 


### PR DESCRIPTION
The logging (especially for the "LogServedAction" is kinda excessive at the moment. I suggest lowering the level to Debug so it doesn't log so much.