### PR TITLE
Restore ability to use null cache

### DIFF
--- a/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using SixLabors.ImageSharp.Web.Commands.Converters;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Providers;
+using SixLabors.ImageSharp.Web.Synchronization;
 
 namespace SixLabors.ImageSharp.Web.DependencyInjection
 {
@@ -56,6 +57,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
             builder.Services.Configure(setupAction);
 
             builder.Services.AddSingleton<FormatUtilities>();
+
+            builder.Services.AddSingleton<AsyncKeyReaderWriterLock<string>>();
 
             builder.SetRequestParser<QueryCollectionRequestParser>();
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -289,7 +289,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
             RecyclableMemoryStream outStream = null;
             try
             {
-                Task<AsyncReaderWriterLock.Releaser> takeLockTask = this.asyncKeyLock.WriterLockAsync(key);
+                Task<IDisposable> takeLockTask = this.asyncKeyLock.WriterLockAsync(key);
                 bool lockWasAlreadyHeld = takeLockTask.Status != TaskStatus.RanToCompletion;
                 using (await takeLockTask)
                 {

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -410,8 +410,8 @@ namespace SixLabors.ImageSharp.Web.Middleware
         }
 
         private async Task<ImageWorkerResult> IsNewOrUpdatedAsync(
-                    IImageResolver sourceImageResolver,
-                    string key)
+            IImageResolver sourceImageResolver,
+            string key)
         {
             // Get the source metadata for processing, storing the result for future checks.
             ImageMetadata sourceImageMetadata = await

--- a/src/ImageSharp.Web/Synchronization/AsyncKeyLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncKeyLock.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace SixLabors.ImageSharp.Web.Synchronization
+{
+    /// <summary>
+    /// Extension of the <see cref="AsyncLock"/> that enables fine-grained locking on a given key.
+    /// Concurrent lock requests using different keys can execute simultaneously, while requests to lock
+    /// using the same key will be forced to wait. This object is thread-safe and internally uses a pooling
+    /// mechanism to minimize allocation of new locks.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    public class AsyncKeyLock<TKey> : IDisposable
+        where TKey : notnull
+    {
+        private readonly RefCountedConcurrentDictionary<TKey, AsyncLock> activeLocks;
+        private readonly ConcurrentBag<AsyncLock> pool;
+        private readonly int maxPoolSize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncKeyLock{TKey}"/> class.
+        /// </summary>
+        /// <param name="maxPoolSize">The maximum number of locks that should be pooled for reuse.</param>
+        public AsyncKeyLock(int maxPoolSize = 64)
+        {
+            this.pool = new ConcurrentBag<AsyncLock>();
+            this.activeLocks = new RefCountedConcurrentDictionary<TKey, AsyncLock>(this.CreateLeasedLock, this.ReturnLeasedLock);
+            this.maxPoolSize = maxPoolSize;
+        }
+
+        /// <summary>
+        /// Locks the current thread asynchronously.
+        /// </summary>
+        /// <param name="key">The key identifying the specific object to lock against.</param>
+        /// <returns>
+        /// The <see cref="AsyncLock.Releaser"/> that will release the lock.
+        /// </returns>
+        public Task<AsyncLock.Releaser> LockAsync(TKey key)
+            => this.activeLocks.Get(key).LockAsync();
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the <see cref="AsyncKeyLock{TKey}"/> class.
+        /// </summary>
+        public void Dispose()
+        {
+            // Dispose of all the locks in the pool
+            while (this.pool.TryTake(out AsyncLock? asyncLock))
+            {
+                asyncLock.Dispose();
+            }
+
+            // activeLocks SHOULD be empty at this point so we don't need to try and clear it out.
+            // If it's not empty, then this object is being disposed of prematurely!
+        }
+
+        private AsyncLock CreateLeasedLock(TKey key)
+        {
+            if (!this.pool.TryTake(out AsyncLock? asyncLock))
+            {
+                asyncLock = new AsyncLock();
+            }
+
+            asyncLock.OnRelease = () => this.activeLocks.Release(key);
+            return asyncLock;
+        }
+
+        private void ReturnLeasedLock(AsyncLock asyncLock)
+        {
+            if (this.pool.Count < this.maxPoolSize)
+            {
+                this.pool.Add(asyncLock);
+            }
+            else
+            {
+                asyncLock.Dispose();
+            }
+        }
+    }
+}

--- a/src/ImageSharp.Web/Synchronization/AsyncKeyLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncKeyLock.cs
@@ -39,9 +39,9 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         /// </summary>
         /// <param name="key">The key identifying the specific object to lock against.</param>
         /// <returns>
-        /// The <see cref="AsyncLock.Releaser"/> that will release the lock.
+        /// The <see cref="IDisposable"/> that will release the lock.
         /// </returns>
-        public Task<AsyncLock.Releaser> LockAsync(TKey key)
+        public Task<IDisposable> LockAsync(TKey key)
             => this.activeLocks.Get(key).LockAsync();
 
         /// <summary>

--- a/src/ImageSharp.Web/Synchronization/AsyncKeyReaderWriterLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncKeyReaderWriterLock.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace SixLabors.ImageSharp.Web.Synchronization
+{
+    /// <summary>
+    /// Extension of the <see cref="AsyncReaderWriterLock"/> that enables fine-grained locking on a given key.
+    /// Concurrent write lock requests using different keys can execute simultaneously, while requests to lock
+    /// using the same key will be forced to wait. This object is thread-safe and internally uses a pooling
+    /// mechanism to minimize allocation of new locks.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    public class AsyncKeyReaderWriterLock<TKey>
+        where TKey : notnull
+    {
+        private readonly RefCountedConcurrentDictionary<TKey, AsyncReaderWriterLock> activeLocks;
+        private readonly ConcurrentBag<AsyncReaderWriterLock> pool;
+        private readonly int maxPoolSize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncKeyReaderWriterLock{TKey}"/> class.
+        /// </summary>
+        /// <param name="maxPoolSize">The maximum number of locks that should be pooled for reuse.</param>
+        public AsyncKeyReaderWriterLock(int maxPoolSize = 64)
+        {
+            this.pool = new ConcurrentBag<AsyncReaderWriterLock>();
+            this.activeLocks = new RefCountedConcurrentDictionary<TKey, AsyncReaderWriterLock>(this.CreateLeasedLock, this.ReturnLeasedLock);
+            this.maxPoolSize = maxPoolSize;
+        }
+
+        /// <summary>
+        /// Locks the current thread in read mode asynchronously.
+        /// </summary>
+        /// <param name="key">The key identifying the specific object to lock against.</param>
+        /// <returns>
+        /// The <see cref="AsyncReaderWriterLock.Releaser"/> that will release the lock.
+        /// </returns>
+        public Task<AsyncReaderWriterLock.Releaser> ReaderLockAsync(TKey key)
+            => this.activeLocks.Get(key).ReaderLockAsync();
+
+        /// <summary>
+        /// Locks the current thread in write mode asynchronously.
+        /// </summary>
+        /// <param name="key">The key identifying the specific object to lock against.</param>
+        /// <returns>
+        /// The <see cref="AsyncReaderWriterLock.Releaser"/> that will release the lock.
+        /// </returns>
+        public Task<AsyncReaderWriterLock.Releaser> WriterLockAsync(TKey key)
+            => this.activeLocks.Get(key).WriterLockAsync();
+
+        private AsyncReaderWriterLock CreateLeasedLock(TKey key)
+        {
+            if (!this.pool.TryTake(out AsyncReaderWriterLock? asyncLock))
+            {
+                asyncLock = new AsyncReaderWriterLock();
+            }
+
+            asyncLock.OnRelease = () => this.activeLocks.Release(key);
+            return asyncLock;
+        }
+
+        private void ReturnLeasedLock(AsyncReaderWriterLock asyncLock)
+        {
+            if (this.pool.Count < this.maxPoolSize)
+            {
+                this.pool.Add(asyncLock);
+            }
+        }
+    }
+}

--- a/src/ImageSharp.Web/Synchronization/AsyncKeyReaderWriterLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncKeyReaderWriterLock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
@@ -38,9 +39,9 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         /// </summary>
         /// <param name="key">The key identifying the specific object to lock against.</param>
         /// <returns>
-        /// The <see cref="AsyncReaderWriterLock.Releaser"/> that will release the lock.
+        /// The <see cref="IDisposable"/> that will release the lock.
         /// </returns>
-        public Task<AsyncReaderWriterLock.Releaser> ReaderLockAsync(TKey key)
+        public Task<IDisposable> ReaderLockAsync(TKey key)
             => this.activeLocks.Get(key).ReaderLockAsync();
 
         /// <summary>
@@ -48,9 +49,9 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         /// </summary>
         /// <param name="key">The key identifying the specific object to lock against.</param>
         /// <returns>
-        /// The <see cref="AsyncReaderWriterLock.Releaser"/> that will release the lock.
+        /// The <see cref="IDisposable"/> that will release the lock.
         /// </returns>
-        public Task<AsyncReaderWriterLock.Releaser> WriterLockAsync(TKey key)
+        public Task<IDisposable> WriterLockAsync(TKey key)
             => this.activeLocks.Get(key).WriterLockAsync();
 
         private AsyncReaderWriterLock CreateLeasedLock(TKey key)

--- a/src/ImageSharp.Web/Synchronization/AsyncLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncLock.cs
@@ -16,9 +16,9 @@ namespace SixLabors.ImageSharp.Web.Synchronization
     {
         private readonly SemaphoreSlim semaphore;
 #pragma warning disable IDE0069 // Disposable fields should be disposed
-        private readonly Releaser releaser;
+        private readonly IDisposable releaser;
 #pragma warning restore IDE0069 // Disposable fields should be disposed
-        private readonly Task<Releaser> releaserTask;
+        private readonly Task<IDisposable> releaserTask;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncLock"/> class.
@@ -36,12 +36,12 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         public Action? OnRelease { get; set; }
 
         /// <summary>
-        /// Asynchronously obtains the lock. Dispose the returned <see cref="Releaser"/> to release the lock.
+        /// Asynchronously obtains the lock. Dispose the returned <see cref="IDisposable"/> to release the lock.
         /// </summary>
         /// <returns>
-        /// The <see cref="Releaser"/> that will release the lock.
+        /// The <see cref="IDisposable"/> that will release the lock.
         /// </returns>
-        public Task<Releaser> LockAsync()
+        public Task<IDisposable> LockAsync()
         {
             Task wait = this.semaphore.WaitAsync();
 
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Web.Synchronization
                 ? this.releaserTask
                 : AwaitThenReturn(wait, this.releaser);
 
-            static async Task<Releaser> AwaitThenReturn(Task t, Releaser r)
+            static async Task<IDisposable> AwaitThenReturn(Task t, IDisposable r)
             {
                 await t;
                 return r;
@@ -77,7 +77,7 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         /// <summary>
         /// Utility class that releases an <see cref="AsyncLock"/> on disposal.
         /// </summary>
-        public sealed class Releaser : IDisposable
+        private sealed class Releaser : IDisposable
         {
             private readonly AsyncLock toRelease;
 

--- a/src/ImageSharp.Web/Synchronization/AsyncLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncLock.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace SixLabors.ImageSharp.Web.Synchronization
+{
+    /// <summary>
+    /// An asynchronous locker that uses an IDisposable pattern for releasing the lock.
+    /// </summary>
+    public class AsyncLock : IDisposable
+    {
+        private readonly SemaphoreSlim semaphore;
+#pragma warning disable IDE0069 // Disposable fields should be disposed
+        private readonly Releaser releaser;
+#pragma warning restore IDE0069 // Disposable fields should be disposed
+        private readonly Task<Releaser> releaserTask;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncLock"/> class.
+        /// </summary>
+        public AsyncLock()
+        {
+            this.semaphore = new SemaphoreSlim(1, 1);
+            this.releaser = new Releaser(this);
+            this.releaserTask = Task.FromResult(this.releaser);
+        }
+
+        /// <summary>
+        /// Gets or sets the callback that should be invoked whenever this lock is released.
+        /// </summary>
+        public Action? OnRelease { get; set; }
+
+        /// <summary>
+        /// Asynchronously obtains the lock. Dispose the returned <see cref="Releaser"/> to release the lock.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Releaser"/> that will release the lock.
+        /// </returns>
+        public Task<Releaser> LockAsync()
+        {
+            Task wait = this.semaphore.WaitAsync();
+
+            // No-allocation fast path when the semaphore wait completed synchronously
+            return (wait.Status == TaskStatus.RanToCompletion)
+                ? this.releaserTask
+                : AwaitThenReturn(wait, this.releaser);
+
+            static async Task<Releaser> AwaitThenReturn(Task t, Releaser r)
+            {
+                await t;
+                return r;
+            }
+        }
+
+        private void Release()
+        {
+            try
+            {
+                this.semaphore.Release();
+            }
+            finally
+            {
+                this.OnRelease?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the <see cref="AsyncLock"/> class.
+        /// </summary>
+        public void Dispose() => this.semaphore.Dispose();
+
+        /// <summary>
+        /// Utility class that releases an <see cref="AsyncLock"/> on disposal.
+        /// </summary>
+        public sealed class Releaser : IDisposable
+        {
+            private readonly AsyncLock toRelease;
+
+            internal Releaser(AsyncLock toRelease) => this.toRelease = toRelease;
+
+            /// <summary>
+            /// Releases the <see cref="AsyncLock"/> associated with this <see cref="Releaser"/>.
+            /// </summary>
+            public void Dispose() => this.toRelease?.Release();
+        }
+    }
+}

--- a/src/ImageSharp.Web/Synchronization/AsyncReaderWriterLock.cs
+++ b/src/ImageSharp.Web/Synchronization/AsyncReaderWriterLock.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace SixLabors.ImageSharp.Web.Synchronization
+{
+    /// <summary>
+    /// An asynchronous locker that provides read and write locking policies.
+    /// <para>
+    /// This is based on the following blog post:
+    /// https://devblogs.microsoft.com/pfxteam/building-async-coordination-primitives-part-7-asyncreaderwriterlock/
+    /// </para>
+    /// </summary>
+    public class AsyncReaderWriterLock
+    {
+        private readonly object stateLock;
+        private readonly Releaser writerReleaser;
+        private readonly Releaser readerReleaser;
+        private readonly Task<Releaser> writerReleaserTask;
+        private readonly Task<Releaser> readerReleaserTask;
+        private readonly Queue<TaskCompletionSource<Releaser>> waitingWriters;
+        private TaskCompletionSource<Releaser>? waitingReaders;
+        private int readersWaiting;
+
+        /// <summary>
+        /// Tracks the current status of the lock:
+        /// 0 == lock is unheld
+        /// -1 == lock is held by a single writer
+        /// >0 == lock is held by this number of concurrent readers
+        /// </summary>
+        private int status;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReaderWriterLock"/> class.
+        /// </summary>
+        public AsyncReaderWriterLock()
+        {
+            this.stateLock = new object();
+            this.writerReleaser = new Releaser(this, true);
+            this.readerReleaser = new Releaser(this, false);
+            this.writerReleaserTask = Task.FromResult(this.writerReleaser);
+            this.readerReleaserTask = Task.FromResult(this.readerReleaser);
+            this.waitingWriters = new Queue<TaskCompletionSource<Releaser>>();
+            this.waitingReaders = null;
+            this.readersWaiting = 0;
+            this.status = 0;
+        }
+
+        /// <summary>
+        /// Gets or sets the callback that should be invoked whenever this lock is released.
+        /// </summary>
+        public Action? OnRelease { get; set; }
+
+        /// <summary>
+        /// Asynchronously obtains the lock in shared reader mode. Dispose the returned <see cref="Releaser"/>
+        /// to release the lock.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Releaser"/> that will release the lock.
+        /// </returns>
+        public Task<Releaser> ReaderLockAsync()
+        {
+            lock (this.stateLock)
+            {
+                if (this.status >= 0 && this.waitingWriters.Count == 0)
+                {
+                    // Lock is not held by a writer and no writers are waiting, so allow this reader to obtain
+                    // the lock immediately and return the pre-allocated reader releaser.
+                    ++this.status;
+                    return this.readerReleaserTask;
+                }
+                else
+                {
+                    // This reader has to wait to obtain the lock.  Lazy instantiate the waitingReader tcs
+                    // and return the task.
+                    ++this.readersWaiting;
+
+                    if (this.waitingReaders == null)
+                    {
+                        this.waitingReaders = new TaskCompletionSource<Releaser>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    }
+
+                    return this.waitingReaders.Task;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously obtains the lock in exclusive writer mode. Dispose the returned <see cref="Releaser"/>
+        /// to release the lock.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Releaser"/> that will release the lock.
+        /// </returns>
+        public Task<Releaser> WriterLockAsync()
+        {
+            lock (this.stateLock)
+            {
+                if (this.status == 0)
+                {
+                    // Lock is currently unheld, so allow this writer to obtain the lock immediately and return the
+                    // pre-allocated writer releaser.
+                    this.status = -1;
+                    return this.writerReleaserTask;
+                }
+                else
+                {
+                    // This writer has to wait to obtain the lock. Create a new tcs for this writer, add it to the
+                    // queue of waiting writers, and return the task.
+                    var waiter = new TaskCompletionSource<Releaser>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    this.waitingWriters.Enqueue(waiter);
+                    return waiter.Task;
+                }
+            }
+        }
+
+        private void ReaderRelease()
+        {
+            try
+            {
+                TaskCompletionSource<Releaser>? nextLockHolder = null;
+
+                lock (this.stateLock)
+                {
+                    --this.status;
+                    if (this.status == 0 && this.waitingWriters.Count > 0)
+                    {
+                        // The lock is now unheld, and there's a writer waiting, so give the lock to the first writer in the queue.
+                        this.status = -1;
+                        nextLockHolder = this.waitingWriters.Dequeue();
+                    }
+                }
+
+                nextLockHolder?.SetResult(this.writerReleaser);
+            }
+            finally
+            {
+                this.OnRelease?.Invoke();
+            }
+        }
+
+        private void WriterRelease()
+        {
+            try
+            {
+                TaskCompletionSource<Releaser>? nextLockHolder;
+                Releaser releaser;
+
+                lock (this.stateLock)
+                {
+                    if (this.waitingWriters.Count > 0)
+                    {
+                        // There's another writer waiting, so pass the lock on to the next writer.
+                        nextLockHolder = this.waitingWriters.Dequeue();
+                        releaser = this.writerReleaser;
+                    }
+                    else if (this.readersWaiting > 0)
+                    {
+                        // There are readers waiting. Wake them all up at the same time since they can all concurrently
+                        // hold the reader lock.
+                        nextLockHolder = this.waitingReaders;
+                        releaser = this.readerReleaser;
+                        this.status = this.readersWaiting;
+                        this.readersWaiting = 0;
+                        this.waitingReaders = null;
+                    }
+                    else
+                    {
+                        // Nobody is waiting, so the lock is now unheld.
+                        this.status = 0;
+                        return;
+                    }
+                }
+
+                nextLockHolder?.SetResult(releaser);
+            }
+            finally
+            {
+                this.OnRelease?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Utility class that releases an <see cref="AsyncReaderWriterLock"/> on disposal.
+        /// </summary>
+        public sealed class Releaser : IDisposable
+        {
+            private readonly AsyncReaderWriterLock toRelease;
+            private readonly bool writer;
+
+            internal Releaser(AsyncReaderWriterLock toRelease, bool writer)
+            {
+                this.toRelease = toRelease;
+                this.writer = writer;
+            }
+
+            /// <summary>
+            /// Releases the <see cref="AsyncReaderWriterLock"/> associated with this <see cref="Releaser"/>.
+            /// </summary>
+            public void Dispose()
+            {
+                if (this.writer)
+                {
+                    this.toRelease.WriterRelease();
+                }
+                else
+                {
+                    this.toRelease.ReaderRelease();
+                }
+            }
+        }
+    }
+}

--- a/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
+++ b/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
@@ -227,10 +227,13 @@ namespace SixLabors.ImageSharp.Web.Synchronization
             }
 
             public bool Equals(
-#if NETCOREAPP3_1_OR_GREATER
-                [System.Diagnostics.CodeAnalysis.AllowNull]
-#endif
+#if NET5_0_OR_GREATER
+                RefCountedValue? other)
+#elif NETCOREAPP3_1_OR_GREATER
+                [System.Diagnostics.CodeAnalysis.AllowNull] RefCountedValue other)
+#else
                 RefCountedValue other)
+#endif
                 => (other != null) && (this.RefCount == other.RefCount) && EqualityComparer<TValue>.Default.Equals(this.Value, other.Value);
 
             public override bool Equals(object? obj)

--- a/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
+++ b/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace SixLabors.ImageSharp.Web.Synchronization
+{
+    /// <summary>
+    /// Represents a thread-safe collection of reference-counted key/value pairs that can be accessed by multiple
+    /// threads concurrently. Values that don't yet exist are automatically created using a caller supplied
+    /// value factory method, and when their final refcount is released they are removed from the dictionary.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TValue">The value for the dictionary.</typeparam>
+    public class RefCountedConcurrentDictionary<TKey, TValue>
+        where TKey : notnull
+        where TValue : class
+    {
+        private readonly ConcurrentDictionary<TKey, RefCountedValue> dictionary;
+        private readonly Func<TKey, TValue> valueFactory;
+        private readonly Action<TValue>? valueReleaser;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> class that is empty,
+        /// has the default concurrency level, has the default initial capacity, and uses the default comparer for the key type.
+        /// </summary>
+        /// <param name="valueFactory">Factory method that generates a new <typeparamref name="TValue"/> for a given <typeparamref name="TKey"/>.</param>
+        /// <param name="valueReleaser">Optional callback that is used to cleanup <typeparamref name="TValue"/>s after their final ref count is released.</param>
+        public RefCountedConcurrentDictionary(Func<TKey, TValue> valueFactory, Action<TValue>? valueReleaser = null)
+            : this(new ConcurrentDictionary<TKey, RefCountedValue>(), valueFactory, valueReleaser)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> class that is empty,
+        /// has the default concurrency level and capacity,, and uses the specified  <see cref="IEqualityComparer{TKey}"/>.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{TKey}"/> implementation to use when comparing keys.</param>
+        /// <param name="valueFactory">Factory method that generates a new <typeparamref name="TValue"/> for a given <typeparamref name="TKey"/>.</param>
+        /// <param name="valueReleaser">Optional callback that is used to cleanup <typeparamref name="TValue"/>s after their final ref count is released.</param>
+        public RefCountedConcurrentDictionary(IEqualityComparer<TKey> comparer, Func<TKey, TValue> valueFactory, Action<TValue>? valueReleaser)
+            : this(new ConcurrentDictionary<TKey, RefCountedValue>(comparer), valueFactory, valueReleaser)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> class that is empty,
+        /// has the specified concurrency level and capacity, and uses the default comparer for the key type.
+        /// </summary>
+        /// <param name="concurrencyLevel">The estimated number of threads that will access the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> concurrently</param>
+        /// <param name="capacity">The initial number of elements that the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> can contain.</param>
+        /// <param name="valueFactory">Factory method that generates a new <typeparamref name="TValue"/> for a given <typeparamref name="TKey"/>.</param>
+        /// <param name="valueReleaser">Optional callback that is used to cleanup <typeparamref name="TValue"/>s after their final ref count is released.</param>
+        public RefCountedConcurrentDictionary(int concurrencyLevel, int capacity, Func<TKey, TValue> valueFactory, Action<TValue>? valueReleaser = null)
+            : this(new ConcurrentDictionary<TKey, RefCountedValue>(concurrencyLevel, capacity), valueFactory, valueReleaser)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> class that is empty,
+        /// has the specified concurrency level, has the specified initial capacity, and uses the specified
+        /// <see cref="IEqualityComparer{TKey}"/>.
+        /// </summary>
+        /// <param name="concurrencyLevel">The estimated number of threads that will access the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> concurrently</param>
+        /// <param name="capacity">The initial number of elements that the <see cref="RefCountedConcurrentDictionary{TKey, TValue}"/> can contain.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{TKey}"/> implementation to use when comparing keys.</param>
+        /// <param name="valueFactory">Factory method that generates a new <typeparamref name="TValue"/> for a given <typeparamref name="TKey"/>.</param>
+        /// <param name="valueReleaser">Optional callback that is used to cleanup <typeparamref name="TValue"/>s after their final ref count is released.</param>
+        public RefCountedConcurrentDictionary(int concurrencyLevel, int capacity, IEqualityComparer<TKey> comparer, Func<TKey, TValue> valueFactory, Action<TValue>? valueReleaser)
+            : this(new ConcurrentDictionary<TKey, RefCountedValue>(concurrencyLevel, capacity, comparer), valueFactory, valueReleaser)
+        {
+        }
+
+        private RefCountedConcurrentDictionary(ConcurrentDictionary<TKey, RefCountedValue> dictionary, Func<TKey, TValue> valueFactory, Action<TValue>? valueReleaser)
+        {
+            Guard.NotNull(valueFactory, nameof(valueFactory));
+
+            this.dictionary = dictionary;
+            this.valueFactory = valueFactory;
+            this.valueReleaser = valueReleaser;
+        }
+
+        /// <summary>
+        /// Obtains a reference to the value corresponding to the specified key. If no such value exists in the
+        /// dictionary, then a new value is generated using the value factory method supplied in the constructor.
+        /// To prevent leaks, this reference MUST be released via <see cref="Release(TKey)"/>.
+        /// </summary>
+        /// <param name="key">The key of the element to add ref.</param>
+        /// <returns>The referenced object.</returns>
+        public TValue Get(TKey key)
+        {
+            while (true)
+            {
+                if (this.dictionary.TryGetValue(key, out RefCountedConcurrentDictionary<TKey, TValue>.RefCountedValue? refCountedValue))
+                {
+                    // Increment ref count
+                    if (this.dictionary.TryUpdate(key, new RefCountedValue(refCountedValue.Value, refCountedValue.RefCount + 1), refCountedValue))
+                    {
+                        return refCountedValue.Value;
+                    }
+                }
+                else
+                {
+                    // Add new value to dictionary
+                    TValue value = this.valueFactory(key);
+
+                    if (this.dictionary.TryAdd(key, new RefCountedValue(value, 1)))
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        this.valueReleaser?.Invoke(value);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Releases a reference to the value corresponding to the specified key. If this reference was the last
+        /// remaining reference to the value, then the value is removed from the dictionary, and the optional value
+        /// releaser callback is invoked.
+        /// </summary>
+        /// <param name="key">THe key of the element to release.</param>
+        public void Release(TKey key)
+        {
+            while (true)
+            {
+                if (!this.dictionary.TryGetValue(key, out RefCountedConcurrentDictionary<TKey, TValue>.RefCountedValue? refCountedValue))
+                {
+                    // This is BAD. It indicates a ref counting problem where someone is either double-releasing,
+                    // or they're releasing a key that they never obtained in the first place!!
+                    throw new InvalidOperationException($"Tried to release value that doesn't exist in the dictionary ({key})!");
+                }
+
+                // If we're releasing the last reference, then try to remove the value from the dictionary.
+                // Otherwise, try to decrement the reference count.
+                if (refCountedValue.RefCount == 1)
+                {
+                    // Remove from dictionary.  We use the ICollection<>.Remove() method instead of the ConcurrentDictionary.TryRemove()
+                    // because this specific API will only succeed if the value hasn't been changed by another thread.
+                    if (((ICollection<KeyValuePair<TKey, RefCountedValue>>)this.dictionary).Remove(new KeyValuePair<TKey, RefCountedValue>(key, refCountedValue)))
+                    {
+                        this.valueReleaser?.Invoke(refCountedValue.Value);
+                        return;
+                    }
+                }
+                else
+                {
+                    // Decrement ref count
+                    if (this.dictionary.TryUpdate(key, new RefCountedValue(refCountedValue.Value, refCountedValue.RefCount - 1), refCountedValue))
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Simple immutable tuple that combines a <typeparamref name="TValue"/> instance with a ref count integer.
+        /// </summary>
+        private class RefCountedValue : IEquatable<RefCountedValue>
+        {
+#pragma warning disable SA1401 // Fields should be private
+            public readonly TValue Value;
+            public readonly int RefCount;
+#pragma warning restore SA1401 // Fields should be private
+
+            public RefCountedValue(TValue value, int refCount)
+            {
+                this.Value = value;
+                this.RefCount = refCount;
+            }
+
+            public bool Equals(
+#if NETCOREAPP3_1_OR_GREATER
+                [System.Diagnostics.CodeAnalysis.AllowNull]
+#endif
+                RefCountedValue other)
+                => (other != null) && (this.RefCount == other.RefCount) && EqualityComparer<TValue>.Default.Equals(this.Value, other.Value);
+
+            public override bool Equals(object? obj)
+                => (obj is RefCountedValue other) && this.Equals(other);
+
+            public override int GetHashCode()
+                => HashCode.Combine(this.RefCount, this.Value);
+        }
+    }
+}

--- a/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
+++ b/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
@@ -96,7 +96,7 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         {
             while (true)
             {
-                if (this.dictionary.TryGetValue(key, out RefCountedConcurrentDictionary<TKey, TValue>.RefCountedValue? refCountedValue))
+                if (this.dictionary.TryGetValue(key, out RefCountedValue? refCountedValue))
                 {
                     // Increment ref count
                     if (this.dictionary.TryUpdate(key, new RefCountedValue(refCountedValue.Value, refCountedValue.RefCount + 1), refCountedValue))
@@ -131,7 +131,7 @@ namespace SixLabors.ImageSharp.Web.Synchronization
         {
             while (true)
             {
-                if (!this.dictionary.TryGetValue(key, out RefCountedConcurrentDictionary<TKey, TValue>.RefCountedValue? refCountedValue))
+                if (!this.dictionary.TryGetValue(key, out RefCountedValue? refCountedValue))
                 {
                     // This is BAD. It indicates a ref counting problem where someone is either double-releasing,
                     // or they're releasing a key that they never obtained in the first place!!
@@ -196,7 +196,7 @@ namespace SixLabors.ImageSharp.Web.Synchronization
             {
                 get
                 {
-                    KeyValuePair<TKey, RefCountedConcurrentDictionary<TKey, TValue>.RefCountedValue> keyValuePair = this.enumerator.Current;
+                    KeyValuePair<TKey, RefCountedValue> keyValuePair = this.enumerator.Current;
                     return (keyValuePair.Key, keyValuePair.Value.Value, keyValuePair.Value.RefCount);
                 }
             }

--- a/tests/ImageSharp.Web.Benchmarks/Synchronization/AsyncLockBenchmarks.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Synchronization/AsyncLockBenchmarks.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using BenchmarkDotNet.Attributes;
+using SixLabors.ImageSharp.Web.Synchronization;
+
+namespace SixLabors.ImageSharp.Web.Benchmarks.Synchronization
+{
+    /// <summary>
+    /// Each of these tests obtains a lock (which completes synchronously as nobody else is holding the lock)
+    /// and then releases that lock.
+    /// </summary>
+    [Config(typeof(MemoryConfig))]
+    public class AsyncLockBenchmarks
+    {
+        private readonly AsyncLock asyncLock = new();
+        private readonly AsyncReaderWriterLock asyncReaderWriterLock = new();
+        private readonly AsyncKeyLock<string> asyncKeyLock = new();
+        private readonly AsyncKeyReaderWriterLock<string> asyncKeyReaderWriterLock = new();
+
+        [Benchmark]
+        public void AsyncLock() => this.asyncLock.LockAsync().Result.Dispose();
+
+        [Benchmark]
+        public void AsyncReaderWriterLock_Reader() => this.asyncReaderWriterLock.ReaderLockAsync().Result.Dispose();
+
+        [Benchmark]
+        public void AsyncReaderWriterLock_Writer() => this.asyncReaderWriterLock.WriterLockAsync().Result.Dispose();
+
+        [Benchmark]
+        public void AsyncKeyLock() => this.asyncKeyLock.LockAsync("key").Result.Dispose();
+
+        [Benchmark]
+        public void AsyncKeyReaderWriterLock_Reader() => this.asyncKeyReaderWriterLock.ReaderLockAsync("key").Result.Dispose();
+
+        [Benchmark]
+        public void AsyncKeyReaderWriterLock_Writer() => this.asyncKeyReaderWriterLock.WriterLockAsync("key").Result.Dispose();
+
+        /*
+        BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1348 (21H1/May2021Update)
+        Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
+        .NET SDK=6.0.100
+            [Host]     : .NET Core 3.1.21 (CoreCLR 4.700.21.51404, CoreFX 4.700.21.51508), X64 RyuJIT
+            DefaultJob : .NET Core 3.1.21 (CoreCLR 4.700.21.51404, CoreFX 4.700.21.51508), X64 RyuJIT
+
+
+        |                          Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
+        |-------------------------------- |----------:|---------:|---------:|-------:|----------:|
+        |                       AsyncLock |  34.93 ns | 0.144 ns | 0.135 ns |      - |         - |
+        |    AsyncReaderWriterLock_Reader |  28.45 ns | 0.117 ns | 0.109 ns |      - |         - |
+        |    AsyncReaderWriterLock_Writer |  28.66 ns | 0.125 ns | 0.117 ns |      - |         - |
+        |                    AsyncKeyLock | 276.48 ns | 5.379 ns | 5.031 ns | 0.0210 |     176 B |
+        | AsyncKeyReaderWriterLock_Reader | 261.96 ns | 1.522 ns | 1.423 ns | 0.0210 |     176 B |
+        | AsyncKeyReaderWriterLock_Writer | 266.35 ns | 1.661 ns | 1.554 ns | 0.0210 |     176 B |
+        */
+    }
+}

--- a/tests/ImageSharp.Web.Benchmarks/Synchronization/RefCountedConcurrentDictionaryBenchmarks.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Synchronization/RefCountedConcurrentDictionaryBenchmarks.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using SixLabors.ImageSharp.Web.Synchronization;
+
+namespace SixLabors.ImageSharp.Web.Benchmarks.Synchronization
+{
+    [Config(typeof(MemoryConfig))]
+    public class RefCountedConcurrentDictionaryBenchmarks
+    {
+        private readonly object testObj;
+        private readonly RefCountedConcurrentDictionary<string, object> refCountedDictionary;
+
+        private readonly ConcurrentDictionary<string, object> dictionary;
+
+        public RefCountedConcurrentDictionaryBenchmarks()
+        {
+            this.testObj = new object();
+            this.refCountedDictionary = new RefCountedConcurrentDictionary<string, object>((_) => this.testObj, null);
+
+            this.dictionary = new ConcurrentDictionary<string, object>();
+
+            this.refCountedDictionary.Get("foo");
+            this.dictionary.TryAdd("foo", this.testObj);
+        }
+
+        [Benchmark]
+        public void RefCountedConcurrentDictionary_ExistingKey()
+        {
+            this.refCountedDictionary.Get("foo");
+            this.refCountedDictionary.Release("foo");
+        }
+
+        [Benchmark]
+        public void RefCountedConcurrentDictionary_ExistingKey_JustGet()
+        {
+            this.refCountedDictionary.Get("foo");
+        }
+
+        [Benchmark]
+        public void ConcurrentDictionary_ExistingKey_JustGet()
+        {
+            this.dictionary.GetOrAdd("foo", this.testObj);
+        }
+
+        [Benchmark]
+        public void RefCountedConcurrentDictionary_NewKey()
+        {
+            this.refCountedDictionary.Get("bar");
+            this.refCountedDictionary.Release("bar");
+        }
+
+        [Benchmark]
+        public void ConcurrentDictionary_NewKey()
+        {
+            this.dictionary.GetOrAdd("bar", this.testObj);
+            this.dictionary.TryRemove("bar", out _);
+        }
+
+        /*
+        BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1348 (21H1/May2021Update)
+        Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
+        .NET SDK=6.0.100
+          [Host]     : .NET Core 3.1.21 (CoreCLR 4.700.21.51404, CoreFX 4.700.21.51508), X64 RyuJIT
+          DefaultJob : .NET Core 3.1.21 (CoreCLR 4.700.21.51404, CoreFX 4.700.21.51508), X64 RyuJIT
+
+
+        |                                             Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
+        |--------------------------------------------------- |----------:|---------:|---------:|-------:|----------:|
+        |         RefCountedConcurrentDictionary_ExistingKey | 138.65 ns | 1.077 ns | 1.007 ns | 0.0076 |      64 B |
+        | RefCountedConcurrentDictionary_ExistingKey_JustGet |  68.00 ns | 0.372 ns | 0.310 ns | 0.0038 |      32 B |
+        |           ConcurrentDictionary_ExistingKey_JustGet |  16.54 ns | 0.117 ns | 0.104 ns |      - |         - |
+        |              RefCountedConcurrentDictionary_NewKey | 131.50 ns | 0.253 ns | 0.237 ns | 0.0095 |      80 B |
+        |                        ConcurrentDictionary_NewKey |  83.55 ns | 0.375 ns | 0.351 ns | 0.0057 |      48 B |
+        */
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncKeyLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncKeyLockTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Web.Synchronization;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Synchronization
+{
+    public class AsyncKeyLockTests
+    {
+        [Fact]
+        public async Task OneAtATime()
+        {
+            AsyncKeyLock<string> l = new();
+
+            Task<IDisposable> first = l.LockAsync("key");
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<IDisposable> second = l.LockAsync("key");
+            Assert.False(second.IsCompleted);
+
+            // Release first hold on the lock
+            first.Result.Dispose();
+
+            // Await the second task to make sure we get the lock.
+            await second;
+
+            l.Dispose();
+        }
+
+        [Fact]
+        public async Task OneAtATime_ByKey()
+        {
+            AsyncKeyLock<string> l = new();
+
+            Task<IDisposable> firstFoo = l.LockAsync("Foo");
+            Assert.True(firstFoo.IsCompletedSuccessfully);
+
+            Task<IDisposable> secondFoo = l.LockAsync("Foo");
+            Assert.False(secondFoo.IsCompleted);
+
+            // Now take a different lock ("bar") and confirm it doesn't conflict with the previous lock
+            Task<IDisposable> firstBar = l.LockAsync("Bar");
+            Assert.True(firstBar.IsCompletedSuccessfully);
+
+            // Release the "bar" lock, and confirm it doesn't change anything about the original "foo" lock.
+            // The second caller that was waiting on the "foo" lock should still be waiting.
+            firstBar.Result.Dispose();
+            Assert.False(secondFoo.IsCompleted);
+
+            // Release the "foo" lock
+            firstFoo.Result.Dispose();
+
+            // Await the second task to make sure it gets the lock.
+            await secondFoo;
+
+            l.Dispose();
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncKeyReaderWriterLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncKeyReaderWriterLockTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Web.Synchronization;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Synchronization
+{
+    public class AsyncKeyReaderWriterLockTests
+    {
+        [Fact]
+        public void OneWriterAtATime()
+        {
+            AsyncKeyReaderWriterLock<string> l = new();
+
+            Task<IDisposable> first = l.WriterLockAsync("key");
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<IDisposable> second = l.WriterLockAsync("key");
+            Assert.False(second.IsCompleted);
+
+            first.Result.Dispose();
+            Assert.True(second.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task OneWriterAtATime_ByKey()
+        {
+            AsyncKeyReaderWriterLock<string> l = new();
+
+            Task<IDisposable> firstFoo = l.WriterLockAsync("Foo");
+            Assert.True(firstFoo.IsCompletedSuccessfully);
+
+            Task<IDisposable> secondFoo = l.WriterLockAsync("Foo");
+            Assert.False(secondFoo.IsCompleted);
+
+            // Now take a different lock ("bar") and confirm it doesn't conflict with the previous lock
+            Task<IDisposable> firstBar = l.WriterLockAsync("Bar");
+            Assert.True(firstBar.IsCompletedSuccessfully);
+
+            // Release the "bar" lock, and confirm it doesn't change anything about the original "foo" lock.
+            // The second caller that was waiting on the "foo" lock should still be waiting.
+            firstBar.Result.Dispose();
+            Assert.False(secondFoo.IsCompleted);
+
+            // Release the "foo" lock
+            firstFoo.Result.Dispose();
+
+            // Await the second task to make sure it gets the lock.
+            await secondFoo;
+        }
+
+        [Fact]
+        public void WriterBlocksReaders()
+        {
+            AsyncKeyReaderWriterLock<string> l = new();
+
+            Task<IDisposable> first = l.WriterLockAsync("key");
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<IDisposable> second = l.ReaderLockAsync("key");
+            Assert.False(second.IsCompleted);
+
+            first.Result.Dispose();
+            Assert.True(second.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void WaitingWriterBlocksReaders()
+        {
+            AsyncKeyReaderWriterLock<string> l = new();
+
+            Task<IDisposable> first = l.ReaderLockAsync("key");
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<IDisposable> second = l.WriterLockAsync("key");
+            Assert.False(second.IsCompleted);
+
+            Task<IDisposable> third = l.ReaderLockAsync("key");
+            Assert.False(third.IsCompleted);
+
+            first.Result.Dispose();
+            Assert.True(second.IsCompletedSuccessfully);
+            Assert.False(third.IsCompleted);
+
+            second.Result.Dispose();
+            Assert.True(third.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void MultipleReadersAtOnce()
+        {
+            AsyncKeyReaderWriterLock<string> l = new();
+
+            Task<IDisposable> first = l.ReaderLockAsync("key");
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<IDisposable> second = l.ReaderLockAsync("key");
+            Assert.True(second.IsCompletedSuccessfully);
+
+            Task<IDisposable> third = l.ReaderLockAsync("key");
+            Assert.True(third.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void AllWaitingReadersReleasedConcurrently()
+        {
+            AsyncKeyReaderWriterLock<string> l = new();
+
+            Task<IDisposable> writer = l.WriterLockAsync("key");
+            Assert.True(writer.IsCompletedSuccessfully);
+
+            Task<IDisposable> reader1 = l.ReaderLockAsync("key");
+            Assert.False(reader1.IsCompleted);
+
+            Task<IDisposable> reader2 = l.ReaderLockAsync("key");
+            Assert.False(reader2.IsCompleted);
+
+            Task<IDisposable> reader3 = l.ReaderLockAsync("key");
+            Assert.False(reader3.IsCompleted);
+
+            writer.Result.Dispose();
+            Assert.True(reader1.IsCompletedSuccessfully);
+            Assert.True(reader2.IsCompletedSuccessfully);
+            Assert.True(reader3.IsCompletedSuccessfully);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncLockTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Web.Synchronization;
 using Xunit;
@@ -14,10 +15,10 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public async Task OneAtATime()
         {
-            Task<AsyncLock.Releaser> first = this.l.LockAsync();
+            Task<IDisposable> first = this.l.LockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<AsyncLock.Releaser> second = this.l.LockAsync();
+            Task<IDisposable> second = this.l.LockAsync();
             Assert.False(second.IsCompleted);
 
             // Release first hold on the lock and then await the second task to confirm it completes.

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncLockTests.cs
@@ -10,22 +10,24 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
 {
     public class AsyncLockTests
     {
-        private readonly AsyncLock l = new();
-
         [Fact]
         public async Task OneAtATime()
         {
-            Task<IDisposable> first = this.l.LockAsync();
+            AsyncLock l = new();
+
+            Task<IDisposable> first = l.LockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<IDisposable> second = this.l.LockAsync();
+            Task<IDisposable> second = l.LockAsync();
             Assert.False(second.IsCompleted);
 
             // Release first hold on the lock and then await the second task to confirm it completes.
             first.Result.Dispose();
 
-            // Await the second task to make sure we get the lock. The timeout specified in the [Fact] above will prevent this from running forever.
+            // Await the second task to make sure we get the lock.
             await second;
+
+            l.Dispose();
         }
     }
 }

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncLockTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Web.Synchronization;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Synchronization
+{
+    public class AsyncLockTests
+    {
+        private readonly AsyncLock l = new();
+
+        [Fact]
+        public async Task OneAtATime()
+        {
+            Task<AsyncLock.Releaser> first = this.l.LockAsync();
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<AsyncLock.Releaser> second = this.l.LockAsync();
+            Assert.False(second.IsCompleted);
+
+            // Release first hold on the lock and then await the second task to confirm it completes.
+            first.Result.Dispose();
+
+            // Await the second task to make sure we get the lock. The timeout specified in the [Fact] above will prevent this from running forever.
+            await second;
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncReaderWriterLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncReaderWriterLockTests.cs
@@ -10,15 +10,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
 {
     public class AsyncReaderWriterLockTests
     {
-        private readonly AsyncReaderWriterLock l = new();
-
         [Fact]
         public void OneWriterAtATime()
         {
-            Task<IDisposable> first = this.l.WriterLockAsync();
+            AsyncReaderWriterLock l = new();
+
+            Task<IDisposable> first = l.WriterLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<IDisposable> second = this.l.WriterLockAsync();
+            Task<IDisposable> second = l.WriterLockAsync();
             Assert.False(second.IsCompleted);
 
             first.Result.Dispose();
@@ -28,10 +28,12 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void WriterBlocksReaders()
         {
-            Task<IDisposable> first = this.l.WriterLockAsync();
+            AsyncReaderWriterLock l = new();
+
+            Task<IDisposable> first = l.WriterLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<IDisposable> second = this.l.ReaderLockAsync();
+            Task<IDisposable> second = l.ReaderLockAsync();
             Assert.False(second.IsCompleted);
 
             first.Result.Dispose();
@@ -41,13 +43,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void WaitingWriterBlocksReaders()
         {
-            Task<IDisposable> first = this.l.ReaderLockAsync();
+            AsyncReaderWriterLock l = new();
+
+            Task<IDisposable> first = l.ReaderLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<IDisposable> second = this.l.WriterLockAsync();
+            Task<IDisposable> second = l.WriterLockAsync();
             Assert.False(second.IsCompleted);
 
-            Task<IDisposable> third = this.l.ReaderLockAsync();
+            Task<IDisposable> third = l.ReaderLockAsync();
             Assert.False(third.IsCompleted);
 
             first.Result.Dispose();
@@ -61,29 +65,33 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void MultipleReadersAtOnce()
         {
-            Task<IDisposable> first = this.l.ReaderLockAsync();
+            AsyncReaderWriterLock l = new();
+
+            Task<IDisposable> first = l.ReaderLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<IDisposable> second = this.l.ReaderLockAsync();
+            Task<IDisposable> second = l.ReaderLockAsync();
             Assert.True(second.IsCompletedSuccessfully);
 
-            Task<IDisposable> third = this.l.ReaderLockAsync();
+            Task<IDisposable> third = l.ReaderLockAsync();
             Assert.True(third.IsCompletedSuccessfully);
         }
 
         [Fact]
         public void AllWaitingReadersReleasedConcurrently()
         {
-            Task<IDisposable> writer = this.l.WriterLockAsync();
+            AsyncReaderWriterLock l = new();
+
+            Task<IDisposable> writer = l.WriterLockAsync();
             Assert.True(writer.IsCompletedSuccessfully);
 
-            Task<IDisposable> reader1 = this.l.ReaderLockAsync();
+            Task<IDisposable> reader1 = l.ReaderLockAsync();
             Assert.False(reader1.IsCompleted);
 
-            Task<IDisposable> reader2 = this.l.ReaderLockAsync();
+            Task<IDisposable> reader2 = l.ReaderLockAsync();
             Assert.False(reader2.IsCompleted);
 
-            Task<IDisposable> reader3 = this.l.ReaderLockAsync();
+            Task<IDisposable> reader3 = l.ReaderLockAsync();
             Assert.False(reader3.IsCompleted);
 
             writer.Result.Dispose();

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncReaderWriterLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncReaderWriterLockTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Web.Synchronization;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Synchronization
+{
+    public class AsyncReaderWriterLockTests
+    {
+        private readonly AsyncReaderWriterLock l = new();
+
+        [Fact]
+        public void OneWriterAtATime()
+        {
+            Task<AsyncReaderWriterLock.Releaser> first = this.l.WriterLockAsync();
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<AsyncReaderWriterLock.Releaser> second = this.l.WriterLockAsync();
+            Assert.False(second.IsCompleted);
+
+            first.Result.Dispose();
+            Assert.True(second.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void WriterBlocksReaders()
+        {
+            Task<AsyncReaderWriterLock.Releaser> first = this.l.WriterLockAsync();
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<AsyncReaderWriterLock.Releaser> second = this.l.ReaderLockAsync();
+            Assert.False(second.IsCompleted);
+
+            first.Result.Dispose();
+            Assert.True(second.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void WaitingWriterBlocksReaders()
+        {
+            Task<AsyncReaderWriterLock.Releaser> first = this.l.ReaderLockAsync();
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<AsyncReaderWriterLock.Releaser> second = this.l.WriterLockAsync();
+            Assert.False(second.IsCompleted);
+
+            Task<AsyncReaderWriterLock.Releaser> third = this.l.ReaderLockAsync();
+            Assert.False(third.IsCompleted);
+
+            first.Result.Dispose();
+            Assert.True(second.IsCompletedSuccessfully);
+            Assert.False(third.IsCompleted);
+
+            second.Result.Dispose();
+            Assert.True(third.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void MultipleReadersAtOnce()
+        {
+            Task<AsyncReaderWriterLock.Releaser> first = this.l.ReaderLockAsync();
+            Assert.True(first.IsCompletedSuccessfully);
+
+            Task<AsyncReaderWriterLock.Releaser> second = this.l.ReaderLockAsync();
+            Assert.True(second.IsCompletedSuccessfully);
+
+            Task<AsyncReaderWriterLock.Releaser> third = this.l.ReaderLockAsync();
+            Assert.True(third.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public void AllWaitingReadersReleasedConcurrently()
+        {
+            Task<AsyncReaderWriterLock.Releaser> writer = this.l.WriterLockAsync();
+            Assert.True(writer.IsCompletedSuccessfully);
+
+            Task<AsyncReaderWriterLock.Releaser> reader1 = this.l.ReaderLockAsync();
+            Assert.False(reader1.IsCompleted);
+
+            Task<AsyncReaderWriterLock.Releaser> reader2 = this.l.ReaderLockAsync();
+            Assert.False(reader2.IsCompleted);
+
+            Task<AsyncReaderWriterLock.Releaser> reader3 = this.l.ReaderLockAsync();
+            Assert.False(reader3.IsCompleted);
+
+            writer.Result.Dispose();
+            Assert.True(reader1.IsCompletedSuccessfully);
+            Assert.True(reader2.IsCompletedSuccessfully);
+            Assert.True(reader3.IsCompletedSuccessfully);
+        }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Synchronization/AsyncReaderWriterLockTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/AsyncReaderWriterLockTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Web.Synchronization;
 using Xunit;
@@ -14,10 +15,10 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void OneWriterAtATime()
         {
-            Task<AsyncReaderWriterLock.Releaser> first = this.l.WriterLockAsync();
+            Task<IDisposable> first = this.l.WriterLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<AsyncReaderWriterLock.Releaser> second = this.l.WriterLockAsync();
+            Task<IDisposable> second = this.l.WriterLockAsync();
             Assert.False(second.IsCompleted);
 
             first.Result.Dispose();
@@ -27,10 +28,10 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void WriterBlocksReaders()
         {
-            Task<AsyncReaderWriterLock.Releaser> first = this.l.WriterLockAsync();
+            Task<IDisposable> first = this.l.WriterLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<AsyncReaderWriterLock.Releaser> second = this.l.ReaderLockAsync();
+            Task<IDisposable> second = this.l.ReaderLockAsync();
             Assert.False(second.IsCompleted);
 
             first.Result.Dispose();
@@ -40,13 +41,13 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void WaitingWriterBlocksReaders()
         {
-            Task<AsyncReaderWriterLock.Releaser> first = this.l.ReaderLockAsync();
+            Task<IDisposable> first = this.l.ReaderLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<AsyncReaderWriterLock.Releaser> second = this.l.WriterLockAsync();
+            Task<IDisposable> second = this.l.WriterLockAsync();
             Assert.False(second.IsCompleted);
 
-            Task<AsyncReaderWriterLock.Releaser> third = this.l.ReaderLockAsync();
+            Task<IDisposable> third = this.l.ReaderLockAsync();
             Assert.False(third.IsCompleted);
 
             first.Result.Dispose();
@@ -60,29 +61,29 @@ namespace SixLabors.ImageSharp.Web.Tests.Synchronization
         [Fact]
         public void MultipleReadersAtOnce()
         {
-            Task<AsyncReaderWriterLock.Releaser> first = this.l.ReaderLockAsync();
+            Task<IDisposable> first = this.l.ReaderLockAsync();
             Assert.True(first.IsCompletedSuccessfully);
 
-            Task<AsyncReaderWriterLock.Releaser> second = this.l.ReaderLockAsync();
+            Task<IDisposable> second = this.l.ReaderLockAsync();
             Assert.True(second.IsCompletedSuccessfully);
 
-            Task<AsyncReaderWriterLock.Releaser> third = this.l.ReaderLockAsync();
+            Task<IDisposable> third = this.l.ReaderLockAsync();
             Assert.True(third.IsCompletedSuccessfully);
         }
 
         [Fact]
         public void AllWaitingReadersReleasedConcurrently()
         {
-            Task<AsyncReaderWriterLock.Releaser> writer = this.l.WriterLockAsync();
+            Task<IDisposable> writer = this.l.WriterLockAsync();
             Assert.True(writer.IsCompletedSuccessfully);
 
-            Task<AsyncReaderWriterLock.Releaser> reader1 = this.l.ReaderLockAsync();
+            Task<IDisposable> reader1 = this.l.ReaderLockAsync();
             Assert.False(reader1.IsCompleted);
 
-            Task<AsyncReaderWriterLock.Releaser> reader2 = this.l.ReaderLockAsync();
+            Task<IDisposable> reader2 = this.l.ReaderLockAsync();
             Assert.False(reader2.IsCompleted);
 
-            Task<AsyncReaderWriterLock.Releaser> reader3 = this.l.ReaderLockAsync();
+            Task<IDisposable> reader3 = this.l.ReaderLockAsync();
             Assert.False(reader3.IsCompleted);
 
             writer.Result.Dispose();

--- a/tests/ImageSharp.Web.Tests/Synchronization/RefCountedConcurrentDictionaryTests.cs
+++ b/tests/ImageSharp.Web.Tests/Synchronization/RefCountedConcurrentDictionaryTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Web.Synchronization;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Synchronization
+{
+    public class RefCountedConcurrentDictionaryTests
+    {
+        private readonly ConcurrentBag<string> released;
+        private readonly RefCountedConcurrentDictionary<string, string> dictionary;
+
+        public RefCountedConcurrentDictionaryTests()
+        {
+            this.released = new ConcurrentBag<string>();
+            this.dictionary = new RefCountedConcurrentDictionary<string, string>(
+                valueFactory: this.ValueForKey,
+                valueReleaser: value => this.released.Add(value));
+        }
+
+        [Fact]
+        public void AddThenRelease()
+        {
+            this.dictionary.Get("test");
+            this.ValidateDictionary(("test", 1));
+            this.ValidateReleased();
+
+            this.dictionary.Release("test");
+            this.ValidateDictionary();
+            this.ValidateReleased("test");
+        }
+
+        [Fact]
+        public void AddTwiceThenReleaseTwice()
+        {
+            this.dictionary.Get("test");
+            this.ValidateDictionary(("test", 1));
+            this.ValidateReleased();
+
+            this.dictionary.Get("test");
+            this.ValidateDictionary(("test", 2));
+            this.ValidateReleased();
+
+            this.dictionary.Release("test");
+            this.ValidateDictionary(("test", 1));
+            this.ValidateReleased();
+
+            this.dictionary.Release("test");
+            this.ValidateDictionary();
+            this.ValidateReleased("test");
+        }
+
+        [Fact]
+        public void AddAndReleaseABunchOfKeys()
+        {
+            this.dictionary.Get("a");
+            this.dictionary.Get("b");
+            this.dictionary.Get("c");
+            this.dictionary.Get("a");
+            this.dictionary.Release("b");
+            this.dictionary.Get("b");
+            this.ValidateDictionary(("a", 2), ("b", 1), ("c", 1));
+            this.ValidateReleased("b");
+
+            this.dictionary.Release("a");
+            this.dictionary.Release("b");
+            this.dictionary.Release("c");
+            this.ValidateDictionary(("a", 1));
+            this.ValidateReleased("b", "b", "c");
+
+            this.dictionary.Release("a");
+            this.ValidateDictionary();
+            this.ValidateReleased("a", "b", "b", "c");
+        }
+
+        [Fact]
+        public async Task StressTest()
+        {
+            string[] keys = new string[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+
+            async Task Worker(int workerIndex)
+            {
+                var random = new Random(workerIndex);
+                for (int i = 0; i < 1000; i++)
+                {
+                    string key = keys[random.Next(0, keys.Length)];
+                    this.dictionary.Get(key);
+                    await Task.Delay(random.Next(0, 2));
+                    this.dictionary.Release(key);
+                }
+            }
+
+            await Task.WhenAll(Enumerable.Range(0, 1000).Select(Worker));
+
+            Assert.Empty(this.dictionary.DebugGetContents());
+        }
+
+        [Fact]
+        public void ReleaseNonExistentThrows()
+            => Assert.Throws<InvalidOperationException>(() => this.dictionary.Release("test"));
+
+        [Fact]
+        public void DoubleReleaseThrows()
+        {
+            this.dictionary.Get("test");
+            this.dictionary.Release("test");
+            Assert.Throws<InvalidOperationException>(() => this.dictionary.Release("test"));
+        }
+
+        [Fact]
+        public void ValueFactoryIsRequired()
+            => Assert.Throws<ArgumentNullException>("valueFactory", () => new RefCountedConcurrentDictionary<string, string>(null!, null));
+
+        private string ValueForKey(string key) => $"{key}.value";
+
+        /// <summary>
+        /// Validate that the dictionary contains precisely the specified key/value/refcount tuples.
+        /// </summary>
+        private void ValidateDictionary(params (string Key, int RefCount)[] expectedValues)
+        {
+            Action<(string, string, int)> CreateElementInspector((string Key, int RefCount) expected)
+                => ((string Key, string Value, int RefCount) actual) =>
+                {
+                    Assert.Equal(expected.Key, actual.Key);
+                    Assert.Equal(this.ValueForKey(expected.Key), actual.Value);
+                    Assert.Equal(expected.RefCount, actual.RefCount);
+                };
+
+            Assert.Collection(
+                collection: this.dictionary.DebugGetContents().OrderBy(v => v.Key),
+                elementInspectors: expectedValues.OrderBy(v => v.Key).Select(CreateElementInspector).ToArray());
+        }
+
+        /// <summary>
+        /// Validate that the specific values were released.
+        /// </summary>
+        private void ValidateReleased(params string[] expectedValues)
+        {
+            Action<string> CreateElementInspector(string expected) => (string actual) => Assert.Equal(this.ValueForKey(expected), actual);
+
+            Assert.Collection(
+                collection: this.released.OrderBy(v => v),
+                elementInspectors: expectedValues.OrderBy(v => v).Select(CreateElementInspector).ToArray());
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
Per the discussion in #193, this PR restores the ability to effectively disable the caching logic through the use of a "NullCache".  The most important part of this change is restoring the ability to stream the response directly from the processed image output, which is how it worked before v1.0.3.  In v1.0.3, the `WriterWorkers` pattern was introduced, and a side effect of that change was that the response was now _always_ streamed from the cache, which broke the ability to use a NullCache.  To address this, I removed the `ReadWorkers`/`WriterWorkers` stuff and replaced it with a more standard reader/writer locking pattern using a synchronization library ported from my company's codebase.  This made it so that the processed image stream could remain available beyond the section of code protected inside the writer lock, and thus be available for use in generating the response.

A key sticking point here (obviously) is benchmark testing this to see if performance was improved or degraded by this change.
