### PR TITLE
Ensure invalid format commands don't get processed.

### DIFF
--- a/src/ImageSharp.Web/FormatUtilities.cs
+++ b/src/ImageSharp.Web/FormatUtilities.cs
@@ -51,14 +51,26 @@ namespace SixLabors.ImageSharp.Web
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string GetExtensionFromUri(string uri)
         {
+            // TODO: This method should follow TryGet pattern. Fix for V2.
             int query = uri.IndexOf('?');
             ReadOnlySpan<char> path;
 
             if (query > -1)
             {
-                if (uri.Contains(FormatWebProcessor.Format, StringComparison.OrdinalIgnoreCase) && QueryHelpers.ParseQuery(uri.Substring(query)).TryGetValue(FormatWebProcessor.Format, out StringValues ext))
+                if (uri.Contains(FormatWebProcessor.Format, StringComparison.OrdinalIgnoreCase)
+                    && QueryHelpers.ParseQuery(uri.Substring(query)).TryGetValue(FormatWebProcessor.Format, out StringValues ext))
                 {
-                    return ext;
+                    // We have a query but is it a valid one?
+                    ReadOnlySpan<char> extSpan = ext[0].AsSpan();
+                    foreach (string extension in this.extensions)
+                    {
+                        if (extSpan.Equals(extension, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return extension;
+                        }
+                    }
+
+                    return null;
                 }
 
                 path = uri.AsSpan(0, query);

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/ImageSharp.Web/Processors/FormatWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/FormatWebProcessor.cs
@@ -37,9 +37,7 @@ namespace SixLabors.ImageSharp.Web.Processors
         /// </summary>
         /// <param name="options">The middleware configuration options.</param>
         public FormatWebProcessor(IOptions<ImageSharpMiddlewareOptions> options)
-        {
-            this.options = options.Value;
-        }
+            => this.options = options.Value;
 
         /// <inheritdoc/>
         public IEnumerable<string> Commands { get; } = FormatCommands;

--- a/tests/ImageSharp.Web.Tests/Helpers/FormatUtilitiesTests.cs
+++ b/tests/ImageSharp.Web.Tests/Helpers/FormatUtilitiesTests.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Helpers
         public static IEnumerable<object[]> DefaultExtensions =
             Configuration.Default.ImageFormats.SelectMany(f => f.FileExtensions.Select(e => new object[] { e, e }));
 
-        private static readonly FormatUtilities FormatUtilities = new FormatUtilities(Options.Create(new ImageSharpMiddlewareOptions()));
+        private static readonly FormatUtilities FormatUtilities = new(Options.Create(new ImageSharpMiddlewareOptions()));
 
         [Theory]
         [MemberData(nameof(DefaultExtensions))]
@@ -27,22 +27,29 @@ namespace SixLabors.ImageSharp.Web.Tests.Helpers
         [Fact]
         public void GetExtensionShouldNotMatchExtensionWithoutDotPrefix()
         {
-            const string Uri = "http://www.example.org/some/path/to/bmpimage";
-            Assert.Null(FormatUtilities.GetExtensionFromUri(Uri));
+            const string uri = "http://www.example.org/some/path/to/bmpimage";
+            Assert.Null(FormatUtilities.GetExtensionFromUri(uri));
         }
 
         [Fact]
         public void GetExtensionShouldIgnoreQueryStringWithoutFormatParamter()
         {
-            const string Uri = "http://www.example.org/some/path/to/image.bmp?width=300&foo=.png";
-            Assert.Equal("bmp", FormatUtilities.GetExtensionFromUri(Uri));
+            const string uri = "http://www.example.org/some/path/to/image.bmp?width=300&foo=.png";
+            Assert.Equal("bmp", FormatUtilities.GetExtensionFromUri(uri));
         }
 
         [Fact]
         public void GetExtensionShouldAcknowledgeQueryStringFormatParameter()
         {
-            const string Uri = "http://www.example.org/some/path/to/image.bmp?width=300&format=png";
-            Assert.Equal("png", FormatUtilities.GetExtensionFromUri(Uri));
+            const string uri = "http://www.example.org/some/path/to/image.bmp?width=300&format=png";
+            Assert.Equal("png", FormatUtilities.GetExtensionFromUri(uri));
+        }
+
+        [Fact]
+        public void GetExtensionShouldRejectInvalidQueryStringFormatParameter()
+        {
+            const string uri = "http://www.example.org/some/path/to/image.bmp?width=300&format=invalid";
+            Assert.Null(FormatUtilities.GetExtensionFromUri(uri));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #195 

Ensures that we don't attempt to process an image request containing an invalid format command.

<!-- Thanks for contributing to ImageSharp! -->
