### PR TITLE
Use more efficient (and not obsolete) download method for Azure Blobs.

### DIFF
--- a/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageCacheResolver.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageCacheResolver.cs
@@ -33,7 +33,6 @@ namespace SixLabors.ImageSharp.Web.Resolvers.Azure
         }
 
         /// <inheritdoc/>
-        public async Task<Stream> OpenReadAsync()
-            => (await this.blob.DownloadAsync()).Value.Content;
+        public Task<Stream> OpenReadAsync() => this.blob.OpenReadAsync();
     }
 }

--- a/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageImageResolver.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Resolvers/AzureBlobStorageImageResolver.cs
@@ -47,7 +47,6 @@ namespace SixLabors.ImageSharp.Web.Resolvers.Azure
         }
 
         /// <inheritdoc/>
-        public async Task<Stream> OpenReadAsync()
-            => (await this.blob.DownloadAsync()).Value.Content;
+        public Task<Stream> OpenReadAsync() => this.blob.OpenReadAsync();
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
`DownloadAsync` is obsolete and inefficient since it downloads the whole blob + content. `OpenReadAsync` streams the blob content directly as the blob is read.

<!-- Thanks for contributing to ImageSharp! -->
