### PR TITLE
Rename PhysicalFileSystemProvider to WebRootImageProvider

### DIFF
--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Web.Sample
                                 provider.GetRequiredService<FormatUtilities>());
                 })
                 .SetCacheHash<CacheHash>()
-                .AddProvider<PhysicalFileSystemProvider>()
+                .AddProvider<WebRootImageProvider>()
                 .AddProcessor<ResizeWebProcessor>()
                 .AddProcessor<FormatWebProcessor>()
                 .AddProcessor<BackgroundColorWebProcessor>()
@@ -131,7 +131,7 @@ namespace SixLabors.ImageSharp.Web.Sample
                 })
                 .SetCacheHash<CacheHash>()
                 .ClearProviders()
-                .AddProvider<PhysicalFileSystemProvider>()
+                .AddProvider<WebRootImageProvider>()
                 .ClearProcessors()
                 .AddProcessor<ResizeWebProcessor>()
                 .AddProcessor<FormatWebProcessor>()

--- a/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
 
             builder.SetCacheHash<CacheHash>();
 
-            builder.AddProvider<PhysicalFileSystemProvider>();
+            builder.AddProvider<WebRootImageProvider>();
 
             builder.AddProcessor<ResizeWebProcessor>()
                    .AddProcessor<FormatWebProcessor>()

--- a/src/ImageSharp.Web/Providers/FileProviderImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/FileProviderImageProvider.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.FileProviders;
+using SixLabors.ImageSharp.Web.Resolvers;
+
+namespace SixLabors.ImageSharp.Web.Providers
+{
+    /// <summary>
+    /// Returns images from an <see cref="IFileProvider"/> abstraction.
+    /// </summary>
+    public class FileProviderImageProvider : IImageProvider
+    {
+        /// <summary>
+        /// The file provider abstraction.
+        /// </summary>
+        private readonly IFileProvider fileProvider;
+
+        /// <summary>
+        /// Contains various format helper methods based on the current configuration.
+        /// </summary>
+        private readonly FormatUtilities formatUtilities;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileProviderImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileProvider">The file provider.</param>
+        /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
+        public FileProviderImageProvider(IFileProvider fileProvider, FormatUtilities formatUtilities)
+        {
+            Guard.NotNull(fileProvider, nameof(fileProvider));
+
+            this.fileProvider = fileProvider;
+            this.formatUtilities = formatUtilities;
+        }
+
+        /// <inheritdoc/>
+        public ProcessingBehavior ProcessingBehavior { get; } = ProcessingBehavior.CommandOnly;
+
+        /// <inheritdoc/>
+        public Func<HttpContext, bool> Match { get; set; } = _ => true;
+
+        /// <inheritdoc/>
+        public virtual bool IsValidRequest(HttpContext context)
+            => this.formatUtilities.TryGetExtensionFromUri(context.Request.GetDisplayUrl(), out _);
+
+        /// <inheritdoc/>
+        public virtual Task<IImageResolver> GetAsync(HttpContext context)
+        {
+            // Path has already been correctly parsed before here
+            IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path.Value);
+
+            // Check to see if the file exists
+            if (!fileInfo.Exists)
+            {
+                return Task.FromResult<IImageResolver>(null);
+            }
+
+            var metadata = new ImageMetadata(fileInfo.LastModified.UtcDateTime, fileInfo.Length);
+
+            return Task.FromResult<IImageResolver>(new FileInfoImageResolver(fileInfo, metadata));
+        }
+    }
+}

--- a/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
@@ -1,31 +1,15 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.Extensions.FileProviders;
-using SixLabors.ImageSharp.Web.Resolvers;
 
 namespace SixLabors.ImageSharp.Web.Providers
 {
     /// <summary>
     /// Returns images from the web root file provider.
     /// </summary>
-    public class WebRootImageProvider : IImageProvider
+    public sealed class WebRootImageProvider : FileProviderImageProvider
     {
-        /// <summary>
-        /// The file provider abstraction.
-        /// </summary>
-        private readonly IFileProvider fileProvider;
-
-        /// <summary>
-        /// Contains various format helper methods based on the current configuration.
-        /// </summary>
-        private readonly FormatUtilities formatUtilities;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="WebRootImageProvider"/> class.
         /// </summary>
@@ -38,39 +22,8 @@ namespace SixLabors.ImageSharp.Web.Providers
             IWebHostEnvironment environment,
 #endif
             FormatUtilities formatUtilities)
+            : base(environment?.WebRootFileProvider, formatUtilities)
         {
-            Guard.NotNull(environment, nameof(environment));
-            Guard.NotNull(environment.WebRootFileProvider, nameof(environment.WebRootFileProvider));
-
-            this.fileProvider = environment.WebRootFileProvider;
-            this.formatUtilities = formatUtilities;
-        }
-
-        /// <inheritdoc/>
-        public ProcessingBehavior ProcessingBehavior { get; } = ProcessingBehavior.CommandOnly;
-
-        /// <inheritdoc/>
-        public Func<HttpContext, bool> Match { get; set; } = _ => true;
-
-        /// <inheritdoc/>
-        public bool IsValidRequest(HttpContext context)
-            => this.formatUtilities.TryGetExtensionFromUri(context.Request.GetDisplayUrl(), out _);
-
-        /// <inheritdoc/>
-        public Task<IImageResolver> GetAsync(HttpContext context)
-        {
-            // Path has already been correctly parsed before here
-            IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path.Value);
-
-            // Check to see if the file exists
-            if (!fileInfo.Exists)
-            {
-                return Task.FromResult<IImageResolver>(null);
-            }
-
-            var metadata = new ImageMetadata(fileInfo.LastModified.UtcDateTime, fileInfo.Length);
-
-            return Task.FromResult<IImageResolver>(new FileInfoImageResolver(fileInfo, metadata));
         }
     }
 }

--- a/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
@@ -12,9 +12,9 @@ using SixLabors.ImageSharp.Web.Resolvers;
 namespace SixLabors.ImageSharp.Web.Providers
 {
     /// <summary>
-    /// Returns images stored in the local physical file system.
+    /// Returns images from the web root file provider.
     /// </summary>
-    public class PhysicalFileSystemProvider : IImageProvider
+    public class WebRootImageProvider : IImageProvider
     {
         /// <summary>
         /// The file provider abstraction.
@@ -27,11 +27,11 @@ namespace SixLabors.ImageSharp.Web.Providers
         private readonly FormatUtilities formatUtilities;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PhysicalFileSystemProvider"/> class.
+        /// Initializes a new instance of the <see cref="WebRootImageProvider"/> class.
         /// </summary>
         /// <param name="environment">The environment used by this middleware.</param>
         /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
-        public PhysicalFileSystemProvider(
+        public WebRootImageProvider(
 #if NETCOREAPP2_1
             IHostingEnvironment environment,
 #else
@@ -59,17 +59,18 @@ namespace SixLabors.ImageSharp.Web.Providers
         /// <inheritdoc/>
         public Task<IImageResolver> GetAsync(HttpContext context)
         {
-            // Path has already been correctly parsed before here.
+            // Path has already been correctly parsed before here
             IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path.Value);
 
-            // Check to see if the file exists.
+            // Check to see if the file exists
             if (!fileInfo.Exists)
             {
                 return Task.FromResult<IImageResolver>(null);
             }
 
             var metadata = new ImageMetadata(fileInfo.LastModified.UtcDateTime, fileInfo.Length);
-            return Task.FromResult<IImageResolver>(new PhysicalFileSystemResolver(fileInfo, metadata));
+
+            return Task.FromResult<IImageResolver>(new FileInfoImageResolver(fileInfo, metadata));
         }
     }
 }

--- a/src/ImageSharp.Web/Resolvers/FileInfoImageResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/FileInfoImageResolver.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+
+namespace SixLabors.ImageSharp.Web.Resolvers
+{
+    /// <summary>
+    /// Provides means to manage image buffers from an <see cref="IImageInfo"/> instance.
+    /// </summary>
+    public class FileInfoImageResolver : IImageResolver
+    {
+        private readonly IFileInfo fileInfo;
+        private readonly ImageMetadata metadata;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileInfoImageResolver"/> class.
+        /// </summary>
+        /// <param name="fileInfo">The input file info.</param>
+        /// <param name="metadata">The image metadata associated with this file.</param>
+        public FileInfoImageResolver(IFileInfo fileInfo, in ImageMetadata metadata)
+        {
+            this.fileInfo = fileInfo;
+            this.metadata = metadata;
+        }
+
+        /// <inheritdoc/>
+        public Task<ImageMetadata> GetMetaDataAsync() => Task.FromResult(this.metadata);
+
+        /// <inheritdoc/>
+        public Task<Stream> OpenReadAsync() => Task.FromResult(this.fileInfo.CreateReadStream());
+    }
+}

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
             Assert.Contains(services, x => x.ServiceType == typeof(IRequestParser) && x.ImplementationType == typeof(QueryCollectionRequestParser));
             Assert.Contains(services, x => x.ServiceType == typeof(IImageCache) && x.ImplementationType == typeof(PhysicalFileSystemCache));
             Assert.Contains(services, x => x.ServiceType == typeof(ICacheHash) && x.ImplementationType == typeof(CacheHash));
-            Assert.Contains(services, x => x.ServiceType == typeof(IImageProvider) && x.ImplementationType == typeof(PhysicalFileSystemProvider));
+            Assert.Contains(services, x => x.ServiceType == typeof(IImageProvider) && x.ImplementationType == typeof(WebRootImageProvider));
             Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(ResizeWebProcessor));
             Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(FormatWebProcessor));
             Assert.Contains(services, x => x.ServiceType == typeof(IImageWebProcessor) && x.ImplementationType == typeof(BackgroundColorWebProcessor));

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageCacheTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageCacheTestServerFixture.cs
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
                     });
                 })
                 .AddProvider(AzureBlobStorageImageProviderFactory.Create)
-                .AddProvider<PhysicalFileSystemProvider>()
+                .AddProvider<WebRootImageProvider>()
                 .AddProcessor<CacheBusterWebProcessor>()
                 .Configure<AzureBlobStorageCacheOptions>(options =>
                 {

--- a/tests/ImageSharp.Web.Tests/TestUtilities/PhysicalFileSystemCacheTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/PhysicalFileSystemCacheTestServerFixture.cs
@@ -78,7 +78,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
                     });
                 })
                 .AddProvider(AzureBlobStorageImageProviderFactory.Create)
-                .AddProvider<PhysicalFileSystemProvider>()
+                .AddProvider<WebRootImageProvider>()
                 .AddProcessor<CacheBusterWebProcessor>();
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
As discussed in https://github.com/SixLabors/ImageSharp.Web/discussions/204, this PR renames the existing `PhysicalFileSystemProvider` to `WebRootImageProvider`.

I've also moved the main implementation into a more generic `FileProviderImageProvider` and added the option to specify a path prefix. The `FileProviderImageProvider` can be used when you serve files that can't be resolved from the `WebRootProvider`, e.g. when you've configured a custom `UseStaticFiles()`. In combination with the path prefix, it's possible to move your images outside the webroot:

After `AddImageSharp()`:
```c#
.ClearProviders() // Required because WebRootImageProvider is added by default and matches all requests
.AddProvider(provider =>
{
    var environment = provider.GetRequiredService<IWebHostEnvironment>();
    var root = Path.Combine(environment.ContentRootPath, "Secret");
    var formatUtilities = provider.GetRequiredService<FormatUtilities>();

    return new FileProviderImageProvider(new PhysicalFileProvider(root), formatUtilities, "/secret");
})
.AddProvider<WebRootImageProvider>()
```

And after `UseImageSharp()`:
```c#
app.UseStaticFiles(new StaticFileOptions()
{
    RequestPath = "/secret",
    FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, "Secret")),
});
```

Another big benefit of this is the possibility to share the `IFileProvider` implementation between the `StaticFileMiddleware` and `ImageSharpMiddleware`. This could greatly simplify the existing `AzureBlobStorageImageProvider` 👍🏻 