### PR TITLE
Remove usage of IFileProvider in PhysicalFileSystemCache

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -35,6 +35,5 @@
     <PackageReference Update="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Update="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-    <PackageReference Update="Microsoft.Extensions.FileProviders.Physical" Version="2.2.0"/>
   </ItemGroup>
 </Project>

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemCacheResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemCacheResolver.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.FileProviders;
 using SixLabors.ImageSharp.Web.Caching;
 
 namespace SixLabors.ImageSharp.Web.Resolvers
@@ -13,7 +12,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
     /// </summary>
     public class PhysicalFileSystemCacheResolver : IImageCacheResolver
     {
-        private readonly IFileInfo metaFileInfo;
+        private readonly FileInfo metaFileInfo;
         private readonly FormatUtilities formatUtilities;
         private ImageCacheMetadata metadata;
 
@@ -24,7 +23,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         /// <param name="formatUtilities">
         /// Contains various format helper methods based on the current configuration.
         /// </param>
-        public PhysicalFileSystemCacheResolver(IFileInfo metaFileInfo, FormatUtilities formatUtilities)
+        public PhysicalFileSystemCacheResolver(FileInfo metaFileInfo, FormatUtilities formatUtilities)
         {
             this.metaFileInfo = metaFileInfo;
             this.formatUtilities = formatUtilities;
@@ -33,7 +32,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         /// <inheritdoc/>
         public async Task<ImageCacheMetadata> GetMetaDataAsync()
         {
-            using Stream stream = this.metaFileInfo.CreateReadStream();
+            using Stream stream = this.metaFileInfo.OpenRead();
             this.metadata = await ImageCacheMetadata.ReadAsync(stream);
             return this.metadata;
         }
@@ -42,7 +41,7 @@ namespace SixLabors.ImageSharp.Web.Resolvers
         public Task<Stream> OpenReadAsync()
         {
             string path = Path.ChangeExtension(
-                this.metaFileInfo.PhysicalPath,
+                this.metaFileInfo.FullName,
                 this.formatUtilities.GetExtensionFromContentType(this.metadata.ContentType));
 
             return Task.FromResult<Stream>(File.OpenRead(path));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
As discussed in https://github.com/SixLabors/ImageSharp.Web/discussions/204, the `PhysicalFileSystemCache` doesn't have to use the `IFileProvider` abstraction, as that only provides read-only access and the cache needs write access.

Another benefit of removing the `PhysicalFileProvider` is that we don't have to create the cache directory in the constructor and can remove the dependency on `Microsoft.Extensions.FileProviders.Physical`.