### PR TITLE
Add CacheFolderDepth option and create shorter file names

### DIFF
--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -51,7 +51,6 @@ namespace SixLabors.ImageSharp.Web.Sample
                     return new PhysicalFileSystemCache(
                                 provider.GetRequiredService<IOptions<PhysicalFileSystemCacheOptions>>(),
                                 provider.GetRequiredService<IWebHostEnvironment>(),
-                                provider.GetRequiredService<IOptions<ImageSharpMiddlewareOptions>>(),
                                 provider.GetRequiredService<FormatUtilities>());
                 })
                 .SetCacheKey<UriRelativeLowerInvariantCacheKey>()
@@ -127,7 +126,6 @@ namespace SixLabors.ImageSharp.Web.Sample
                     return new PhysicalFileSystemCache(
                         provider.GetRequiredService<IOptions<PhysicalFileSystemCacheOptions>>(),
                         provider.GetRequiredService<IWebHostEnvironment>(),
-                        provider.GetRequiredService<IOptions<ImageSharpMiddlewareOptions>>(),
                         provider.GetRequiredService<FormatUtilities>());
                 })
                 .SetCacheKey<UriRelativeLowerInvariantCacheKey>()

--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Web.Sample
                                 provider.GetRequiredService<FormatUtilities>());
                 })
                 .SetCacheKey<UriRelativeLowerInvariantCacheKey>()
-                .SetCacheHash<CacheHash>()
+                .SetCacheHash<SHA256CacheHash>()
                 .AddProvider<PhysicalFileSystemProvider>()
                 .AddProcessor<ResizeWebProcessor>()
                 .AddProcessor<FormatWebProcessor>()
@@ -131,7 +131,7 @@ namespace SixLabors.ImageSharp.Web.Sample
                         provider.GetRequiredService<FormatUtilities>());
                 })
                 .SetCacheKey<UriRelativeLowerInvariantCacheKey>()
-                .SetCacheHash<CacheHash>()
+                .SetCacheHash<SHA256CacheHash>()
                 .ClearProviders()
                 .AddProvider<PhysicalFileSystemProvider>()
                 .ClearProcessors()

--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Web.Sample
                         options.Configuration = Configuration.Default;
                         options.BrowserMaxAge = TimeSpan.FromDays(7);
                         options.CacheMaxAge = TimeSpan.FromDays(365);
-                        options.CachedNameLength = 8;
+                        options.CacheHashLength = 8;
                         options.OnParseCommandsAsync = _ => Task.CompletedTask;
                         options.OnBeforeSaveAsync = _ => Task.CompletedTask;
                         options.OnProcessedAsync = _ => Task.CompletedTask;
@@ -111,7 +111,7 @@ namespace SixLabors.ImageSharp.Web.Sample
                         options.Configuration = Configuration.Default;
                         options.BrowserMaxAge = TimeSpan.FromDays(7);
                         options.CacheMaxAge = TimeSpan.FromDays(365);
-                        options.CachedNameLength = 8;
+                        options.CacheHashLength = 8;
                         options.OnParseCommandsAsync = _ => Task.CompletedTask;
                         options.OnBeforeSaveAsync = _ => Task.CompletedTask;
                         options.OnProcessedAsync = _ => Task.CompletedTask;

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -152,6 +152,12 @@ namespace SixLabors.ImageSharp.Web.Caching
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe string ToFilePath(string key, int cacheFolderDepth)
         {
+            if (cacheFolderDepth == 0)
+            {
+                // Short-circuit when not nesting folders
+                return key;
+            }
+
             int length;
             int nameStartIndex;
             if (cacheFolderDepth >= key.Length)

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
@@ -4,7 +4,7 @@
 namespace SixLabors.ImageSharp.Web.Caching
 {
     /// <summary>
-    /// Configuration options for the <see cref="PhysicalFileSystemCache"/>.
+    /// Configuration options for the <see cref="PhysicalFileSystemCache" />.
     /// </summary>
     public class PhysicalFileSystemCacheOptions
     {
@@ -12,6 +12,11 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// Gets or sets the cache folder name.
         /// </summary>
         public string CacheFolder { get; set; } = "is-cache";
+
+        /// <summary>
+        /// Gets or sets the depth of the nested cache folders structure to store the images.
+        /// </summary>
+        public uint CacheFolderDepth { get; set; } = 8;
 
         /// <summary>
         /// Gets or sets the optional cache root folder.

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         public string CacheFolder { get; set; } = "is-cache";
 
         /// <summary>
-        /// Gets or sets the depth of the nested cache folders structure to store the images.
+        /// Gets or sets the depth of the nested cache folders structure to store the images. Defaults to 8.
         /// </summary>
         public uint CacheFolderDepth { get; set; } = 8;
 

--- a/src/ImageSharp.Web/Caching/SHA256CacheHash.cs
+++ b/src/ImageSharp.Web/Caching/SHA256CacheHash.cs
@@ -16,13 +16,13 @@ namespace SixLabors.ImageSharp.Web.Caching
     /// Hashed keys are the result of the SHA256 computation of the input value for the given length.
     /// This ensures low collision rates with a shorter file name.
     /// </summary>
-    public sealed class CacheHash : ICacheHash
+    public sealed class SHA256CacheHash : ICacheHash
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CacheHash"/> class.
+        /// Initializes a new instance of the <see cref="SHA256CacheHash"/> class.
         /// </summary>
         /// <param name="options">The middleware configuration options.</param>
-        public CacheHash(IOptions<ImageSharpMiddlewareOptions> options)
+        public SHA256CacheHash(IOptions<ImageSharpMiddlewareOptions> options)
         {
             Guard.NotNull(options, nameof(options));
             Guard.MustBeBetweenOrEqualTo<uint>(options.Value.CachedNameLength, 2, 64, nameof(options.Value.CachedNameLength));
@@ -34,8 +34,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         {
             int byteCount = Encoding.ASCII.GetByteCount(value);
 
-            // Allocating a buffer from the pool is ~27% slower than stackalloc so use
-            // that for short strings
+            // Allocating a buffer from the pool is ~27% slower than stackalloc so use that for short strings
             if (byteCount < 257)
             {
                 return HashValue(value, length, stackalloc byte[byteCount]);
@@ -62,11 +61,11 @@ namespace SixLabors.ImageSharp.Web.Caching
             using var hashAlgorithm = SHA256.Create();
             Encoding.ASCII.GetBytes(value, bufferSpan);
 
-            // Hashed output maxes out at 32 bytes @ 256bit/8 so we're safe to use stackalloc.
+            // Hashed output maxes out at 32 bytes @ 256bit/8 so we're safe to use stackalloc
             Span<byte> hash = stackalloc byte[32];
             hashAlgorithm.TryComputeHash(bufferSpan, hash, out int _);
 
-            // length maxes out at 64 since we throw if options is greater.
+            // Length maxes out at 64 since we throw if options is greater
             return HexEncoder.Encode(hash.Slice(0, (int)(length / 2)));
         }
     }

--- a/src/ImageSharp.Web/Caching/SHA256CacheHash.cs
+++ b/src/ImageSharp.Web/Caching/SHA256CacheHash.cs
@@ -25,7 +25,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         public SHA256CacheHash(IOptions<ImageSharpMiddlewareOptions> options)
         {
             Guard.NotNull(options, nameof(options));
-            Guard.MustBeBetweenOrEqualTo<uint>(options.Value.CachedNameLength, 2, 64, nameof(options.Value.CachedNameLength));
+            Guard.MustBeBetweenOrEqualTo<uint>(options.Value.CacheHashLength, 2, 64, nameof(options.Value.CacheHashLength));
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
 
             builder.SetCacheKey<UriRelativeLowerInvariantCacheKey>();
 
-            builder.SetCacheHash<CacheHash>();
+            builder.SetCacheHash<SHA256CacheHash>();
 
             builder.AddProvider<PhysicalFileSystemProvider>();
 

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -271,7 +271,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
             // Create a hashed cache key
             string key = this.cacheHash.Create(
                 this.cacheKey.Create(context, commands),
-                this.options.CachedNameLength);
+                this.options.CacheHashLength);
 
             // Check the cache, if present, not out of date and not requiring an update
             // we'll simply serve the file from there.

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// Gets or sets the length of the filename to use (minus the extension) when storing
         /// images in the image cache. Defaults to 12 characters.
         /// </summary>
-        public uint CachedNameLength { get; set; } = 12;
+        public uint CacheHashLength { get; set; } = 12;
 
         /// <summary>
         /// Gets or sets the additional command parsing method that can be used to used to augment commands.

--- a/tests/ImageSharp.Web.Benchmarks/Caching/CacheHashBenchmarks.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Caching/CacheHashBenchmarks.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Web.Benchmarks.Caching
     {
         private const string URL = "http://testwebsite.com/image-12345.jpeg?width=400";
         private static readonly IOptions<ImageSharpMiddlewareOptions> MWOptions = Options.Create(new ImageSharpMiddlewareOptions());
-        private static readonly CacheHash Sha256Hasher = new CacheHash(MWOptions);
+        private static readonly SHA256CacheHash Sha256Hasher = new SHA256CacheHash(MWOptions);
         private static readonly CacheHashBaseline NaiveSha256Hasher = new CacheHashBaseline();
 
         [Benchmark(Baseline = true, Description = "Baseline Sha256Hasher")]

--- a/tests/ImageSharp.Web.Benchmarks/Caching/StringJoinBenchmarks.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Caching/StringJoinBenchmarks.cs
@@ -12,11 +12,13 @@ namespace SixLabors.ImageSharp.Web.Benchmarks.Caching
     public class StringJoinBenchmarks
     {
         private const string Key = "abcdefghijkl";
-        private const int CachedNameLength = 12;
+
+        [Params(0, 8, 12)]
+        public int CacheFolderDepth { get; set; }
 
         [Benchmark(Baseline = true, Description = "String.Join")]
         public string JoinUsingString()
-            => $"{string.Join("/", Key.Substring(0, CachedNameLength).ToCharArray())}/{Key}";
+            => $"{string.Join("/", Key.Substring(0, this.CacheFolderDepth).ToCharArray())}/{Key}";
 
         [Benchmark(Description = "StringBuilder.Append")]
         public string JoinUsingStringBuilder()
@@ -25,8 +27,8 @@ namespace SixLabors.ImageSharp.Web.Benchmarks.Caching
             const char separator = '/';
 
             // Each key substring char + separator + key
-            var sb = new StringBuilder((CachedNameLength * 2) + Key.Length);
-            ReadOnlySpan<char> paths = keySpan.Slice(0, CachedNameLength);
+            var sb = new StringBuilder((this.CacheFolderDepth * 2) + Key.Length);
+            ReadOnlySpan<char> paths = keySpan.Slice(0, this.CacheFolderDepth);
             for (int i = 0; i < paths.Length; i++)
             {
                 sb.Append(paths[i]);
@@ -39,7 +41,7 @@ namespace SixLabors.ImageSharp.Web.Benchmarks.Caching
 
         [Benchmark(Description = "String.Create")]
         public string JoinUsingStringCreate()
-            => PhysicalFileSystemCache.ToFilePath(Key, CachedNameLength);
+            => PhysicalFileSystemCache.ToFilePath(Key, this.CacheFolderDepth);
 
         /*
         BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363

--- a/tests/ImageSharp.Web.Tests/Caching/CacheHashTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/CacheHashTests.cs
@@ -13,7 +13,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
     public class CacheHashTests
     {
         private static readonly IOptions<ImageSharpMiddlewareOptions> Options = MSOptions.Create(new ImageSharpMiddlewareOptions());
-        private static readonly ICacheHash CacheHash = new CacheHash(Options);
+        private static readonly ICacheHash CacheHash = new SHA256CacheHash(Options);
 
         [Fact]
         public void CacheHashProducesIdenticalResults()

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -8,14 +8,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
 {
     public class PhysicialFileSystemCacheTests
     {
-        [Fact]
-        public void FilePathMatchesReference()
+        [Theory]
+        [InlineData("abcdefghijkl", 0, "abcdefghijkl")]
+        [InlineData("abcdefghijkl", 4, "a/b/c/d/efghijkl")]
+        [InlineData("abcdefghijkl", 8, "a/b/c/d/e/f/g/h/ijkl")]
+        [InlineData("abcdefghijkl", 12, "a/b/c/d/e/f/g/h/i/j/k/l/abcdefghijkl")]
+        [InlineData("abcdefghijkl", 16, "a/b/c/d/e/f/g/h/i/j/k/l/abcdefghijkl")]
+        public void FilePathMatchesReference(string key, int cacheFolderDepth, string expected)
         {
-            const string Key = "abcdefghijkl";
-            const int CachedNameLength = 12;
-
-            string expected = $"{string.Join("/", Key.Substring(0, CachedNameLength).ToCharArray())}/{Key}";
-            string actual = PhysicalFileSystemCache.ToFilePath(Key, CachedNameLength);
+            string actual = PhysicalFileSystemCache.ToFilePath(key, cacheFolderDepth);
 
             Assert.Equal(expected, actual);
         }

--- a/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/tests/ImageSharp.Web.Tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Web.Tests.DependencyInjection
             Assert.Single(services, IsServiceImplementationType<IRequestParser, QueryCollectionRequestParser>);
             Assert.Single(services, IsServiceImplementationType<IImageCache, PhysicalFileSystemCache>);
             Assert.Single(services, IsServiceImplementationType<ICacheKey, UriRelativeLowerInvariantCacheKey>);
-            Assert.Single(services, IsServiceImplementationType<ICacheHash, CacheHash>);
+            Assert.Single(services, IsServiceImplementationType<ICacheHash, SHA256CacheHash>);
             Assert.Single(services, IsServiceImplementationType<IImageProvider, PhysicalFileSystemProvider>);
             Assert.Single(services, IsServiceImplementationType<IImageWebProcessor, ResizeWebProcessor>);
             Assert.Single(services, IsServiceImplementationType<IImageWebProcessor, FormatWebProcessor>);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This is my second try to separate the cache hash length and folder depth as discussed in https://github.com/SixLabors/ImageSharp.Web/discussions/210, but without introducing a new option to keep creating backwards compatible cache file paths as done in https://github.com/SixLabors/ImageSharp.Web/pull/212.

In ImageSharp.Web v1 the folder depth is using the same value as the cache hash (with a default of 12), so the nested folders contain all characters from the file name. With this new implementation, it removes the characters used for the folders from the file name (to generate shorter file paths), but this would leave no characters left for the actual file name when these values are equal: `027ee1e815be.meta` would result in `0/2/7/e/e/1/e/8/1/5/b/e/.meta`. In this case, the implementation switches back to the old behavior and generates: `0/2/7/e/e/1/e/8/1/5/b/e/027ee1e815be.meta`. This thus removes the need for an additional setting and reverting back to the legacy behavior is as simple as setting both the `ImageSharpMiddlewareOptions.CacheHashLength` and `PhysicalFileSystemCacheOptions.CacheFolderDepth` to the same value.