### PR TITLE
Decouple PhysicalFileSystemProvider from WebRootFileProvider

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,8 +21,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
-    <PackageReference Update="SixLabors.ImageSharp"  Version="2.0.0-alpha.0.156" />
+    <PackageReference Update="SixLabors.ImageSharp"  Version="2.0.0-alpha.0.165" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/ImageSharp.Web/Caching/LegacyV1CacheKey.cs
+++ b/src/ImageSharp.Web/Caching/LegacyV1CacheKey.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Web.Caching
 {
     /// <summary>
     /// Maintained for compatibility purposes only this cache key implementation generates the same
-    /// out as the V1 middleware. If possible, it is recommended to use the <see cref="UriRelativeCacheKey"/>.
+    /// out as the V1 middleware. If possible, it is recommended to use the <see cref="UriRelativeLowerInvariantCacheKey"/>.
     /// </summary>
     public class LegacyV1CacheKey : ICacheKey
     {

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -58,7 +58,7 @@ namespace SixLabors.ImageSharp.Web.Caching
             Guard.NotNullOrWhiteSpace(environment.WebRootPath, nameof(environment.WebRootPath));
 
             // Allow configuration of the cache without having to register everything
-            PhysicalFileSystemCacheOptions cacheOptions = options != null ? options.Value : new PhysicalFileSystemCacheOptions();
+            PhysicalFileSystemCacheOptions cacheOptions = options != null ? options.Value : new();
             this.cacheRootPath = GetCacheRoot(cacheOptions, environment.WebRootPath, environment.ContentRootPath);
             this.cacheFolderDepth = (int)cacheOptions.CacheFolderDepth;
 
@@ -72,13 +72,13 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <summary>
         /// Determine the cache root path
         /// </summary>
-        /// <param name="cacheOptions">the cache options.</param>
-        /// <param name="webRootPath">the webRootPath.</param>
-        /// <param name="contentRootPath">the contentRootPath.</param>
-        /// <returns>root path.</returns>
+        /// <param name="cacheOptions">The cache options.</param>
+        /// <param name="webRootPath">The web root path.</param>
+        /// <param name="contentRootPath">The content root path.</param>
+        /// <returns><see cref="string"/> representing the fully qualified cache root path.</returns>
         internal static string GetCacheRoot(PhysicalFileSystemCacheOptions cacheOptions, string webRootPath, string contentRootPath)
         {
-            string cacheRoot = string.IsNullOrEmpty(cacheOptions.CacheRoot)
+            string cacheRoot = string.IsNullOrWhiteSpace(cacheOptions.CacheRoot)
                 ? webRootPath
                 : cacheOptions.CacheRoot;
 

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -78,9 +78,9 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <returns><see cref="string"/> representing the fully qualified cache root path.</returns>
         internal static string GetCacheRoot(PhysicalFileSystemCacheOptions cacheOptions, string webRootPath, string contentRootPath)
         {
-            string cacheRoot = string.IsNullOrWhiteSpace(cacheOptions.CacheRoot)
+            string cacheRoot = string.IsNullOrWhiteSpace(cacheOptions.CacheRootPath)
                 ? webRootPath
-                : cacheOptions.CacheRoot;
+                : cacheOptions.CacheRootPath;
 
             return Path.IsPathFullyQualified(cacheRoot)
                 ? Path.Combine(cacheRoot, cacheOptions.CacheFolder)

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCacheOptions.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         public uint CacheFolderDepth { get; set; } = 8;
 
         /// <summary>
-        /// Gets or sets the optional cache root folder.
+        /// Gets or sets the optional cache root folder path.
         /// <para>
         /// This value can be <see langword="null"/>, a fully qualified absolute path,
         /// or a path relative to the directory that contains the application
@@ -30,6 +30,6 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// application content files; commonly 'wwwroot'.
         /// </para>
         /// </summary>
-        public string CacheRoot { get; set; }
+        public string CacheRootPath { get; set; }
     }
 }

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Commands.Converters;
@@ -47,27 +46,6 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
             builder.Services.Replace(descriptor);
             return builder;
         }
-
-        /// <summary>
-        /// Sets the given <see cref="MemoryAllocator"/> adding it to the service collection.
-        /// </summary>
-        /// <param name="builder">The core builder.</param>
-        /// <param name="implementationFactory">The factory method for returning a <see cref="MemoryAllocator"/>.</param>
-        /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
-        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.", true)]
-        public static IImageSharpBuilder SetMemoryAllocator(this IImageSharpBuilder builder, Func<IServiceProvider, MemoryAllocator> implementationFactory)
-            => builder;
-
-        /// <summary>
-        /// Sets the given <see cref="MemoryAllocator"/> adding it to the service collection.
-        /// </summary>
-        /// <typeparam name="TMemoryAllocator">The type of class implementing <see cref="MemoryAllocator"/>to add.</typeparam>
-        /// <param name="builder">The core builder.</param>
-        /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
-        [Obsolete("Use ImageSharp.Configuration.MemoryAllocator. This will be removed in a future version.", true)]
-        public static IImageSharpBuilder SetMemoryAllocator<TMemoryAllocator>(this IImageSharpBuilder builder)
-            where TMemoryAllocator : MemoryAllocator
-            => builder;
 
         /// <summary>
         /// Sets the given <see cref="IImageCache"/> adding it to the service collection.

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -96,10 +96,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// </summary>
         public Func<ImageCommandContext, Task> OnParseCommandsAsync
         {
-            get
-            {
-                return this.onParseCommandsAsync;
-            }
+            get => this.onParseCommandsAsync;
 
             set
             {
@@ -115,10 +112,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// </summary>
         public Func<FormattedImage, Task> OnBeforeSaveAsync
         {
-            get
-            {
-                return this.onBeforeSaveAsync;
-            }
+            get => this.onBeforeSaveAsync;
 
             set
             {
@@ -134,10 +128,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// </summary>
         public Func<ImageProcessingContext, Task> OnProcessedAsync
         {
-            get
-            {
-                return this.onProcessedAsync;
-            }
+            get => this.onProcessedAsync;
 
             set
             {
@@ -153,10 +144,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// </summary>
         public Func<HttpContext, Task> OnPrepareResponseAsync
         {
-            get
-            {
-                return this.onPrepareResponseAsync;
-            }
+            get => this.onPrepareResponseAsync;
 
             set
             {

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -94,9 +94,9 @@ namespace SixLabors.ImageSharp.Web.Providers
         /// <returns><see cref="string"/> representing the fully qualified provider root path.</returns>
         internal static string GetProviderRoot(PhysicalFileSystemProviderOptions providerOptions, string webRootPath, string contentRootPath)
         {
-            string providerRoot = string.IsNullOrWhiteSpace(providerOptions.ProviderRoot)
+            string providerRoot = string.IsNullOrWhiteSpace(providerOptions.ProviderRootPath)
                 ? webRootPath
-                : providerOptions.ProviderRoot;
+                : providerOptions.ProviderRootPath;
 
             return Path.IsPathFullyQualified(providerRoot)
                 ? providerRoot

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -51,11 +51,11 @@ namespace SixLabors.ImageSharp.Web.Providers
 
             // Allow configuration of the provider without having to register everything
             PhysicalFileSystemProviderOptions providerOptions = options != null ? options.Value : new();
-            string cacheRootPath = GetProviderRoot(providerOptions, environment.WebRootPath, environment.ContentRootPath);
+            string providerRootPath = GetProviderRoot(providerOptions, environment.WebRootPath, environment.ContentRootPath);
 
             // Ensure provider directory is created before initializing the file provider
-            Directory.CreateDirectory(cacheRootPath);
-            this.fileProvider = new PhysicalFileProvider(cacheRootPath);
+            Directory.CreateDirectory(providerRootPath);
+            this.fileProvider = new PhysicalFileProvider(providerRootPath);
             this.formatUtilities = formatUtilities;
         }
 

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProviderOptions.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProviderOptions.cs
@@ -9,7 +9,7 @@ namespace SixLabors.ImageSharp.Web.Providers
     public class PhysicalFileSystemProviderOptions
     {
         /// <summary>
-        /// Gets or sets the optional provider root folder.
+        /// Gets or sets the optional provider root folder path.
         /// <para>
         /// This value can be <see langword="null"/>, a fully qualified absolute path,
         /// or a path relative to the directory that contains the application
@@ -20,6 +20,6 @@ namespace SixLabors.ImageSharp.Web.Providers
         /// application content files; commonly 'wwwroot'.
         /// </para>
         /// </summary>
-        public string ProviderRoot { get; set; }
+        public string ProviderRootPath { get; set; }
     }
 }

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProviderOptions.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProviderOptions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Web.Providers
+{
+    /// <summary>
+    /// Configuration options for the <see cref="PhysicalFileSystemProvider" />.
+    /// </summary>
+    public class PhysicalFileSystemProviderOptions
+    {
+        /// <summary>
+        /// Gets or sets the optional provider root folder.
+        /// <para>
+        /// This value can be <see langword="null"/>, a fully qualified absolute path,
+        /// or a path relative to the directory that contains the application
+        /// content files.
+        /// </para>
+        /// <para>
+        /// If not set, this will default to the directory that contains the web-servable
+        /// application content files; commonly 'wwwroot'.
+        /// </para>
+        /// </summary>
+        public string ProviderRoot { get; set; }
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
             var cacheOptions = new PhysicalFileSystemCacheOptions
             {
                 CacheFolder = cacheFolder,
-                CacheRoot = cacheRoot
+                CacheRootPath = cacheRoot
             };
 
             string cacheRootResult = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, webRootPath, contentRootPath);

--- a/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
+++ b/tests/ImageSharp.Web.Tests/Caching/PhysicialFileSystemCacheTests.cs
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Caching
                 CacheRoot = cacheRoot
             };
 
-            var cacheRootResult = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, webRootPath, contentRootPath);
+            string cacheRootResult = PhysicalFileSystemCache.GetCacheRoot(cacheOptions, webRootPath, contentRootPath);
 
             Assert.Equal(expected, cacheRootResult);
         }

--- a/tests/ImageSharp.Web.Tests/Providers/PhysicalFileSystemProviderTests.cs
+++ b/tests/ImageSharp.Web.Tests/Providers/PhysicalFileSystemProviderTests.cs
@@ -10,17 +10,17 @@ namespace SixLabors.ImageSharp.Web.Tests.Providers
     {
         [Theory]
 #if OS_LINUX
-        [InlineData(null, "wwwroot", "Users/root/", "Users/root/wwwroot")]
-        [InlineData(null, "Users/WebRoot", "Users/root/", "Users/WebRoot")]
-        [InlineData("providerFolder", "../Temp", "Users/this/a/root", "Users/this/a/root/providerFolder")]
-        [InlineData("../Temp", null, "Users/this/a/root", "Users/this/a/Temp")]
-        [InlineData("Users/WebRoot", null, "Users/this/a/root", "Users/WebRoot")]
+        [InlineData(null, "wwwroot", "/Users/root/", "/Users/root/wwwroot")]
+        [InlineData(null, "/Users/WebRoot", "/Users/root/", "/Users/WebRoot")]
+        [InlineData("providerFolder", "../Temp", "/Users/this/a/root", "/Users/this/a/root/providerFolder")]
+        [InlineData("../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp")]
+        [InlineData("/Users/WebRoot", null, "/Users/this/a/root", "/Users/WebRoot")]
 #elif OS_OSX
-        [InlineData(null, "wwwroot", "Users/root/", "Users/root/wwwroot")]
-        [InlineData(null, "Users/WebRoot", "Users/root/", "Users/WebRoot")]
-        [InlineData("providerFolder", "../Temp", "Users/this/a/root", "Users/this/a/root/providerFolder")]
-        [InlineData("../Temp", null, "Users/this/a/root", "Users/this/a/Temp")]
-        [InlineData("Users/WebRoot", null, "Users/this/a/root", "Users/WebRoot")]
+        [InlineData(null, "wwwroot", "/Users/root/", "/Users/root/wwwroot")]
+        [InlineData(null, "/Users/WebRoot", "/Users/root/", "/Users/WebRoot")]
+        [InlineData("providerFolder", "../Temp", "/Users/this/a/root", "/Users/this/a/root/providerFolder")]
+        [InlineData("../Temp", null, "/Users/this/a/root", "/Users/this/a/Temp")]
+        [InlineData("/Users/WebRoot", null, "/Users/this/a/root", "/Users/WebRoot")]
 #elif OS_WINDOWS
         [InlineData(null, "wwwroot", "C:/root\\", "C:\\root\\wwwroot")]
         [InlineData(null, "C:/WebRoot", "C:/root\\", "C:/WebRoot")]
@@ -28,7 +28,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Providers
         [InlineData("../Temp", null, "C:/this/a/root", "C:\\this\\a\\Temp")]
         [InlineData("C:/WebRoot", null, "C:/this/a/root", "C:/WebRoot")]
 #endif
-        public void CacheRootFromOptions(string providerRoot, string webRootPath, string contentRootPath, string expected)
+        public void ProvidersRootFromOptions(string providerRoot, string webRootPath, string contentRootPath, string expected)
         {
             var providerOptions = new PhysicalFileSystemProviderOptions
             {

--- a/tests/ImageSharp.Web.Tests/Providers/PhysicalFileSystemProviderTests.cs
+++ b/tests/ImageSharp.Web.Tests/Providers/PhysicalFileSystemProviderTests.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Providers
         {
             var providerOptions = new PhysicalFileSystemProviderOptions
             {
-                ProviderRoot = providerRoot,
+                ProviderRootPath = providerRoot,
             };
 
             string providerRootResult = PhysicalFileSystemProvider.GetProviderRoot(providerOptions, webRootPath, contentRootPath);

--- a/tests/ImageSharp.Web.Tests/Providers/PhysicalFileSystemProviderTests.cs
+++ b/tests/ImageSharp.Web.Tests/Providers/PhysicalFileSystemProviderTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Web.Providers;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Providers
+{
+    public class PhysicalFileSystemProviderTests
+    {
+        [Theory]
+#if OS_LINUX
+        [InlineData(null, "wwwroot", "Users/root/", "Users/root/wwwroot")]
+        [InlineData(null, "Users/WebRoot", "Users/root/", "Users/WebRoot")]
+        [InlineData("providerFolder", "../Temp", "Users/this/a/root", "Users/this/a/root/providerFolder")]
+        [InlineData("../Temp", null, "Users/this/a/root", "Users/this/a/Temp")]
+        [InlineData("Users/WebRoot", null, "Users/this/a/root", "Users/WebRoot")]
+#elif OS_OSX
+        [InlineData(null, "wwwroot", "Users/root/", "Users/root/wwwroot")]
+        [InlineData(null, "Users/WebRoot", "Users/root/", "Users/WebRoot")]
+        [InlineData("providerFolder", "../Temp", "Users/this/a/root", "Users/this/a/root/providerFolder")]
+        [InlineData("../Temp", null, "Users/this/a/root", "Users/this/a/Temp")]
+        [InlineData("Users/WebRoot", null, "Users/this/a/root", "Users/WebRoot")]
+#elif OS_WINDOWS
+        [InlineData(null, "wwwroot", "C:/root\\", "C:\\root\\wwwroot")]
+        [InlineData(null, "C:/WebRoot", "C:/root\\", "C:/WebRoot")]
+        [InlineData("providerFolder", "../Temp", "C:/this/a/root", "C:\\this\\a\\root\\providerFolder")]
+        [InlineData("../Temp", null, "C:/this/a/root", "C:\\this\\a\\Temp")]
+        [InlineData("C:/WebRoot", null, "C:/this/a/root", "C:/WebRoot")]
+#endif
+        public void CacheRootFromOptions(string providerRoot, string webRootPath, string contentRootPath, string expected)
+        {
+            var providerOptions = new PhysicalFileSystemProviderOptions
+            {
+                ProviderRoot = providerRoot,
+            };
+
+            string providerRootResult = PhysicalFileSystemProvider.GetProviderRoot(providerOptions, webRootPath, contentRootPath);
+
+            Assert.Equal(expected, providerRootResult);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This PR decouples the `PhysicalFileSystemProvider ` from the environment `WebRootFileProvider` allowing it to work independently bringing greater freedom for source image storage within the physical file system. It should be none breaking since it defaults to the existing source location when the new `PhysicalFileSystemProviderOptions.ProviderRootPath` property is not set.

See https://github.com/SixLabors/ImageSharp.Web/discussions/204#discussioncomment-2055878 for reference. 

I've additionally done a little required cleanup.

<!-- Thanks for contributing to ImageSharp! -->
