### PR TITLE
Respect EXIF orientation when resizing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,160 +1,172 @@
 name: Build
 
 on:
-    push:
-        branches:
-            - master
-        tags:
-            - "v*"
-    pull_request:
-        branches:
-            - master
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - master
 
 jobs:
-    Build:
-        strategy:
-            matrix:
-                options:
-                    - os: macos-latest
-                      framework: netcoreapp3.1
-                      runtime: -x64
-                      codecov: false
-                    - os: ubuntu-latest
-                      framework: netcoreapp3.1
-                      runtime: -x64
-                      codecov: false
-                    - os: windows-latest
-                      framework: netcoreapp3.1
-                      runtime: -x64
-                      codecov: true
-                    - os: windows-latest
-                      framework: netcoreapp2.1
-                      runtime: -x64
-                      codecov: false
+  Build:
+    strategy:
+      matrix:
+        options:
+          - os: macos-latest
+            framework: netcoreapp3.1
+            runtime: -x64
+            codecov: false
+          - os: ubuntu-latest
+            framework: netcoreapp3.1
+            runtime: -x64
+            codecov: false
+          - os: windows-latest
+            framework: netcoreapp3.1
+            runtime: -x64
+            codecov: true
+          - os: windows-latest
+            framework: netcoreapp2.1
+            runtime: -x64
+            codecov: false
 
-        runs-on: ${{matrix.options.os}}
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ${{matrix.options.os}}
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
-        steps:
-            - uses: actions/checkout@v2
+    steps:
+      - name: Git Config
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.longpaths true
 
-            # See https://github.com/actions/checkout/issues/165#issuecomment-657673315
-            - name: Create LFS file list
-              run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - name: Git Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-            - name: Restore LFS cache
-              uses: actions/cache@v2
-              id: lfs-cache
-              with:
-                path: .git/lfs
-                key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+      # See https://github.com/actions/checkout/issues/165#issuecomment-657673315
+      - name: Git Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
-            - name: Git LFS Pull
-              run: git lfs pull
+      - name: Restore LFS cache
+        uses: actions/cache@v2
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
 
-            - name: Setup .NET SDKs
-              uses: actions/setup-dotnet@v1
-              with:
-                dotnet-version: |
-                  6.0.x
-                  5.0.x
-                  3.1.x
-                  2.1.x
+      - name: Git Pull LFS
+        run: git lfs pull
 
-            - name: Install NuGet
-              uses: NuGet/setup-nuget@v1
+      - name: NuGet Install
+        uses: NuGet/setup-nuget@v1
 
-            - name: Setup Git
-              shell: bash
-              run: |
-                  git config --global core.autocrlf false
-                  git config --global core.longpaths true
-                  git fetch --prune --unshallow
-                  git submodule -q update --init --recursive
+      - name: NuGet Setup Cache
+        uses: actions/cache@v2
+        id: nuget-cache
+        with:
+          path: ~/.nuget
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
-            - name: Setup Azurite
-              if: matrix.options.os != 'windows-latest'
-              shell: bash
-              run: |
-                  sudo npm install -g azurite
-                  sudo azurite --loose &
+      - name: Azurite Setup
+        if: matrix.options.os != 'windows-latest'
+        shell: bash
+        run: |
+          sudo npm install -g azurite
+          sudo azurite --loose &
 
-            - name: Setup Azurite Windows
-              if: matrix.options.os == 'windows-latest'
-              shell: bash
-              run: |
-                  npm install -g azurite
-                  azurite --loose &
+      - name: Azurite Setup Windows
+        if: matrix.options.os == 'windows-latest'
+        shell: bash
+        run: |
+          npm install -g azurite
+          azurite --loose &
 
-            - name: Setup s3rver
-              if: matrix.options.os != 'windows-latest'
-              shell: bash
-              run: |
-                  sudo npm install -g s3rver
-                  sudo s3rver -d . &
+      - name: S3rver Setup
+        if: matrix.options.os != 'windows-latest'
+        shell: bash
+        run: |
+          sudo npm install -g s3rver
+          sudo s3rver -d . &
 
-            - name: Setup s3rver Windows
-              if: matrix.options.os == 'windows-latest'
-              shell: bash
-              run: |
-                  npm install -g s3rver
-                  s3rver -d . &
+      - name: S3rver Setup Windows
+        if: matrix.options.os == 'windows-latest'
+        shell: bash
+        run: |
+          npm install -g s3rver
+          s3rver -d . &
 
-            - name: Setup NuGet Cache
-              uses: actions/cache@v2
-              id: nuget-cache
-              with:
-                  path: ~/.nuget
-                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
-                  restore-keys: ${{ runner.os }}-nuget-
+      - name: DotNet Setup
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            6.0.x
+            5.0.x
+            3.1.x
+            2.1.x
 
-            - name: Build
-              shell: pwsh
-              run: ./ci-build.ps1 "${{matrix.options.framework}}"
-              env:
-                SIXLABORS_TESTING: True
+      - name: DotNet Build
+        shell: pwsh
+        run: ./ci-build.ps1 "${{matrix.options.framework}}"
+        env:
+          SIXLABORS_TESTING: True
 
-            - name: Test
-              shell: pwsh
-              run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
-              env:
-                  SIXLABORS_TESTING: True
-                  XUNIT_PATH: .\tests\ImageSharp.Web.Tests # Required for xunit
+      - name: DotNet Test
+        shell: pwsh
+        run: ./ci-test.ps1 "${{matrix.options.os}}" "${{matrix.options.framework}}" "${{matrix.options.runtime}}" "${{matrix.options.codecov}}"
+        env:
+          SIXLABORS_TESTING: True
+          XUNIT_PATH: .\tests\ImageSharp.Web.Tests # Required for xunit
 
-            - name: Update Codecov
-              uses: codecov/codecov-action@v1
-              if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
-              with:
-                  flags: unittests
+      - name: Codecov Update
+        uses: codecov/codecov-action@v1
+        if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
+        with:
+          flags: unittests
 
-    Publish:
-        needs: [Build]
+  Publish:
+    needs: [Build]
 
-        runs-on: windows-latest
+    runs-on: ubuntu-latest
 
-        if: (github.event_name == 'push')
+    if: (github.event_name == 'push')
 
-        steps:
-            - uses: actions/checkout@v2
+    steps:
+      - name: Git Config
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.longpaths true
 
-            - name: Install NuGet
-              uses: NuGet/setup-nuget@v1
+      - name: Git Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-            - name: Setup Git
-              shell: bash
-              run: |
-                  git config --global core.autocrlf false
-                  git config --global core.longpaths true
-                  git fetch --prune --unshallow
-                  git submodule -q update --init --recursive
+      - name: NuGet Install
+        uses: NuGet/setup-nuget@v1
 
-            - name: Pack
-              shell: pwsh
-              run: ./ci-pack.ps1
+      - name: NuGet Setup Cache
+        uses: actions/cache@v2
+        id: nuget-cache
+        with:
+          path: ~/.nuget
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: ${{ runner.os }}-nuget-
 
-            - name: Publish to MyGet
-              shell: pwsh
-              run: |
-                  nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
-                  nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
-              # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org
+      - name: DotNet Pack
+        shell: pwsh
+        run: ./ci-pack.ps1
+
+      - name: MyGet Publish
+        shell: pwsh
+        run: |
+          dotnet nuget push .\artifacts\*.nupkg -k ${{secrets.MYGET_TOKEN}} -s https://www.myget.org/F/sixlabors/api/v2/package
+          dotnet nuget push .\artifacts\*.snupkg -k ${{secrets.MYGET_TOKEN}} -s https://www.myget.org/F/sixlabors/api/v3/index.json
+        # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Git Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
-      - name: Restore LFS cache
+      - name: Git Setup LFS Cache
         uses: actions/cache@v2
         id: lfs-cache
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,6 +52,15 @@ jobs:
             - name: Git LFS Pull
               run: git lfs pull
 
+            - name: Setup .NET SDKs
+              uses: actions/setup-dotnet@v1
+              with:
+                dotnet-version: |
+                  6.0.x
+                  5.0.x
+                  3.1.x
+                  2.1.x
+
             - name: Install NuGet
               uses: NuGet/setup-nuget@v1
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,7 +21,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Update="SixLabors.ImageSharp"  Version="2.0.0-alpha.0.165" />
+    <PackageReference Update="SixLabors.ImageSharp"  Version="2.0.0-alpha.0.172" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/SixLabors/ImageSharp.Web/</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
-    <PackageTags>Image Middleware Resize Crop Gif Jpg Jpeg Bitmap Png Core Cache ASP</PackageTags>
+    <PackageTags>Image Middleware Resize Crop Gif Jpg Jpeg Bitmap Png WebP Tiff Core Cache ASP</PackageTags>
     <Description>ImageSharp Middleware for serving images via a url based API.</Description>
   </PropertyGroup>
 

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Web.Processors
         /// <summary>
         /// The command constant for the resize orientation handling mode.
         /// </summary>
-        public const string Orient = "rorient";
+        public const string Orient = "orient";
 
         /// <summary>
         /// The command constant for the resize compand mode.

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 using SixLabors.ImageSharp.Web.Commands;
@@ -41,9 +42,14 @@ namespace SixLabors.ImageSharp.Web.Processors
         public const string Sampler = "rsampler";
 
         /// <summary>
-        /// The command constant for the resize sampler.
+        /// The command constant for the resize anchor position.
         /// </summary>
         public const string Anchor = "ranchor";
+
+        /// <summary>
+        /// The command constant for the resize orientation handling mode.
+        /// </summary>
+        public const string Orient = "rorient";
 
         /// <summary>
         /// The command constant for the resize compand mode.
@@ -59,7 +65,8 @@ namespace SixLabors.ImageSharp.Web.Processors
                 Mode,
                 Sampler,
                 Anchor,
-                Compand
+                Compand,
+                Orient
             };
 
         /// <inheritdoc/>
@@ -73,7 +80,7 @@ namespace SixLabors.ImageSharp.Web.Processors
             CommandParser parser,
             CultureInfo culture)
         {
-            ResizeOptions options = GetResizeOptions(commands, parser, culture);
+            ResizeOptions options = GetResizeOptions(image.Image, commands, parser, culture);
 
             if (options != null)
             {
@@ -84,6 +91,7 @@ namespace SixLabors.ImageSharp.Web.Processors
         }
 
         private static ResizeOptions GetResizeOptions(
+            Image image,
             CommandCollection commands,
             CommandParser parser,
             CultureInfo culture)
@@ -93,7 +101,7 @@ namespace SixLabors.ImageSharp.Web.Processors
                 return null;
             }
 
-            Size size = ParseSize(commands, parser, culture);
+            Size size = ParseSize(image, commands, parser, culture);
 
             if (size.Width <= 0 && size.Height <= 0)
             {
@@ -116,15 +124,38 @@ namespace SixLabors.ImageSharp.Web.Processors
         }
 
         private static Size ParseSize(
+            Image image,
             CommandCollection commands,
             CommandParser parser,
             CultureInfo culture)
         {
             // The command parser will reject negative numbers as it clamps values to ranges.
-            uint width = parser.ParseValue<uint>(commands.GetValueOrDefault(Width), culture);
-            uint height = parser.ParseValue<uint>(commands.GetValueOrDefault(Height), culture);
+            int width = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Width), culture);
+            int height = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Height), culture);
 
-            return new Size((int)width, (int)height);
+            // Browsers now implement 'image-orientation: from-image' by default.
+            // https://developer.mozilla.org/en-US/docs/web/css/image-orientation
+            // This makes orientation handling confusing for users who expect images to be resized in accordance
+            // to what they observe rather than pure (and correct) methods.
+            //
+            // To accomodate this we parse the dimensions to use based upon decoded EXIF orientation values, switching
+            // the width/height parameters when images are rotated (not flipped).
+            // We default to 'true' for EXIF orientation handling. By passing 'false' it can be turned off.
+            if (!commands.Contains(Orient) || parser.ParseValue<bool>(commands.GetValueOrDefault(Orient), culture))
+            {
+                if (image.Metadata.ExifProfile != null)
+                {
+                    IExifValue<ushort> orientation = image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
+                    return orientation.Value switch
+                    {
+                        // LeftTop, RightTop, RightBottom, LeftBottom
+                        5 or 6 or 7 or 8 => new Size(height, width),
+                        _ => new Size(width, height),
+                    };
+                }
+            }
+
+            return new Size(width, height);
         }
 
         private static PointF? GetCenter(
@@ -166,40 +197,25 @@ namespace SixLabors.ImageSharp.Web.Processors
 
             if (sampler != null)
             {
-                switch (sampler.ToLowerInvariant())
+                // No need to do a case test here. Parsed commands are automatically converted to lowercase.
+                return sampler switch
                 {
-                    case "nearest":
-                    case "nearestneighbor":
-                        return KnownResamplers.NearestNeighbor;
-                    case "box":
-                        return KnownResamplers.Box;
-                    case "mitchell":
-                    case "mitchellnetravali":
-                        return KnownResamplers.MitchellNetravali;
-                    case "catmull":
-                    case "catmullrom":
-                        return KnownResamplers.CatmullRom;
-                    case "lanczos2":
-                        return KnownResamplers.Lanczos2;
-                    case "lanczos3":
-                        return KnownResamplers.Lanczos3;
-                    case "lanczos5":
-                        return KnownResamplers.Lanczos5;
-                    case "lanczos8":
-                        return KnownResamplers.Lanczos8;
-                    case "welch":
-                        return KnownResamplers.Welch;
-                    case "robidoux":
-                        return KnownResamplers.Robidoux;
-                    case "robidouxsharp":
-                        return KnownResamplers.RobidouxSharp;
-                    case "spline":
-                        return KnownResamplers.Spline;
-                    case "triangle":
-                        return KnownResamplers.Triangle;
-                    case "hermite":
-                        return KnownResamplers.Hermite;
-                }
+                    "nearest" or "nearestneighbor" => KnownResamplers.NearestNeighbor,
+                    "box" => KnownResamplers.Box,
+                    "mitchell" or "mitchellnetravali" => KnownResamplers.MitchellNetravali,
+                    "catmull" or "catmullrom" => KnownResamplers.CatmullRom,
+                    "lanczos2" => KnownResamplers.Lanczos2,
+                    "lanczos3" => KnownResamplers.Lanczos3,
+                    "lanczos5" => KnownResamplers.Lanczos5,
+                    "lanczos8" => KnownResamplers.Lanczos8,
+                    "welch" => KnownResamplers.Welch,
+                    "robidoux" => KnownResamplers.Robidoux,
+                    "robidouxsharp" => KnownResamplers.RobidouxSharp,
+                    "spline" => KnownResamplers.Spline,
+                    "triangle" => KnownResamplers.Triangle,
+                    "hermite" => KnownResamplers.Hermite,
+                    _ => KnownResamplers.Bicubic,
+                };
             }
 
             return KnownResamplers.Bicubic;

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -148,8 +148,10 @@ namespace SixLabors.ImageSharp.Web.Processors
                     IExifValue<ushort> orientation = image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
                     return orientation.Value switch
                     {
-                        // LeftTop, RightTop, RightBottom, LeftBottom
-                        5 or 6 or 7 or 8 => new Size(height, width),
+                        ExifOrientationMode.LeftTop
+                        or ExifOrientationMode.RightTop
+                        or ExifOrientationMode.RightBottom
+                        or ExifOrientationMode.LeftBottom => new Size(height, width),
                         _ => new Size(width, height),
                     };
                 }

--- a/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Web.Commands;
@@ -50,7 +51,9 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
 
             CommandCollection commands = new()
             {
-                { new(ResizeWebProcessor.Sampler, resampler) },
+                // We only need to do this for the unit tests.
+                // Commands generated via URL will automatically be converted to lowecase
+                { new(ResizeWebProcessor.Sampler, resampler.ToLowerInvariant()) },
                 { new(ResizeWebProcessor.Width, width.ToString()) },
                 { new(ResizeWebProcessor.Height, height.ToString()) },
                 { new(ResizeWebProcessor.Xy, "0,0") },
@@ -58,6 +61,105 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
             };
 
             using var image = new Image<Rgba32>(1, 1);
+            using var formatted = new FormattedImage(image, PngFormat.Instance);
+            new ResizeWebProcessor().Process(formatted, null, commands, parser, culture);
+
+            Assert.Equal(width, image.Width);
+            Assert.Equal(height, image.Height);
+        }
+
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(1, false)]
+        [InlineData(2, false)]
+        [InlineData(3, false)]
+        [InlineData(4, false)]
+        [InlineData(5, true)]
+        [InlineData(6, true)]
+        [InlineData(7, true)]
+        [InlineData(8, true)]
+        public void ResizeWebProcessor_RespectsOrientation(ushort orientation, bool rotated)
+        {
+            const int width = 4;
+            const int height = 6;
+
+            var converters = new List<ICommandConverter>
+            {
+                new IntegralNumberConverter<uint>(),
+                new ArrayConverter<float>(),
+                new EnumConverter(),
+                new SimpleCommandConverter<bool>(),
+                new SimpleCommandConverter<float>()
+            };
+
+            var parser = new CommandParser(converters);
+            CultureInfo culture = CultureInfo.InvariantCulture;
+
+            CommandCollection commands = new()
+            {
+                { new(ResizeWebProcessor.Width, width.ToString()) },
+                { new(ResizeWebProcessor.Height, height.ToString()) },
+                { new(ResizeWebProcessor.Mode, nameof(ResizeMode.Stretch)) }
+            };
+
+            using var image = new Image<Rgba32>(1, 1);
+            image.Metadata.ExifProfile = new();
+            image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, orientation);
+
+            using var formatted = new FormattedImage(image, PngFormat.Instance);
+            new ResizeWebProcessor().Process(formatted, null, commands, parser, culture);
+
+            if (rotated)
+            {
+                Assert.Equal(height, image.Width);
+                Assert.Equal(width, image.Height);
+            }
+            else
+            {
+                Assert.Equal(width, image.Width);
+                Assert.Equal(height, image.Height);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        public void ResizeWebProcessor_CanIgnoreOrientation(ushort orientation)
+        {
+            const int width = 4;
+            const int height = 6;
+
+            var converters = new List<ICommandConverter>
+            {
+                new IntegralNumberConverter<uint>(),
+                new ArrayConverter<float>(),
+                new EnumConverter(),
+                new SimpleCommandConverter<bool>(),
+                new SimpleCommandConverter<float>()
+            };
+
+            var parser = new CommandParser(converters);
+            CultureInfo culture = CultureInfo.InvariantCulture;
+
+            CommandCollection commands = new()
+            {
+                { new(ResizeWebProcessor.Width, width.ToString()) },
+                { new(ResizeWebProcessor.Height, height.ToString()) },
+                { new(ResizeWebProcessor.Mode, nameof(ResizeMode.Stretch)) },
+                { new(ResizeWebProcessor.Orient, bool.FalseString) }
+            };
+
+            using var image = new Image<Rgba32>(1, 1);
+            image.Metadata.ExifProfile = new();
+            image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, orientation);
+
             using var formatted = new FormattedImage(image, PngFormat.Instance);
             new ResizeWebProcessor().Process(formatted, null, commands, parser, culture);
 

--- a/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
@@ -69,15 +69,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
         }
 
         [Theory]
-        [InlineData(0, false)]
-        [InlineData(1, false)]
-        [InlineData(2, false)]
-        [InlineData(3, false)]
-        [InlineData(4, false)]
-        [InlineData(5, true)]
-        [InlineData(6, true)]
-        [InlineData(7, true)]
-        [InlineData(8, true)]
+        [InlineData(ExifOrientationMode.Unknown, false)]
+        [InlineData(ExifOrientationMode.TopLeft, false)]
+        [InlineData(ExifOrientationMode.TopRight, false)]
+        [InlineData(ExifOrientationMode.BottomRight, false)]
+        [InlineData(ExifOrientationMode.BottomLeft, false)]
+        [InlineData(ExifOrientationMode.LeftTop, true)]
+        [InlineData(ExifOrientationMode.RightTop, true)]
+        [InlineData(ExifOrientationMode.RightBottom, true)]
+        [InlineData(ExifOrientationMode.LeftBottom, true)]
         public void ResizeWebProcessor_RespectsOrientation(ushort orientation, bool rotated)
         {
             const int width = 4;
@@ -122,15 +122,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
         }
 
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        [InlineData(8)]
+        [InlineData(ExifOrientationMode.Unknown)]
+        [InlineData(ExifOrientationMode.TopLeft)]
+        [InlineData(ExifOrientationMode.TopRight)]
+        [InlineData(ExifOrientationMode.BottomRight)]
+        [InlineData(ExifOrientationMode.BottomLeft)]
+        [InlineData(ExifOrientationMode.LeftTop)]
+        [InlineData(ExifOrientationMode.RightTop)]
+        [InlineData(ExifOrientationMode.RightBottom)]
+        [InlineData(ExifOrientationMode.LeftBottom)]
         public void ResizeWebProcessor_CanIgnoreOrientation(ushort orientation)
         {
             const int width = 4;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
In addition to #215 we need the ability to resize images containing EXIF orientation metadata that specifies rotation based upon the users [observed expectation](https://twitter.com/James_M_South/status/1489219049532067842) without updating the EXIF metadata.

This PR updates the `ResizeWebProcessor` to swap dimensions parsed from command when a value indicating EXIF rotation is detected. This behavior can be turned off per request by passing the command `orient=false` (_Note I've deliberately not used an `r` prefix to make this more reusable for other potential transforming processors_).

<!-- Thanks for contributing to ImageSharp! -->
cc\ @ronaldbarendse 