### PR TITLE
Separate AWS cache options and normalize implementations

### DIFF
--- a/src/ImageSharp.Web.Providers.AWS/AmazonS3ClientFactory.cs
+++ b/src/ImageSharp.Web.Providers.AWS/AmazonS3ClientFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using Amazon;
 using Amazon.S3;
-using SixLabors.ImageSharp.Web.Providers.AWS;
 
 namespace SixLabors.ImageSharp.Web
 {
@@ -18,7 +17,7 @@ namespace SixLabors.ImageSharp.Web
         /// <returns>
         /// A new <see cref="AmazonS3Client"/>.
         /// </returns>
-        public static AmazonS3Client CreateClient(AWSS3BucketClientOptions options)
+        public static AmazonS3Client CreateClient(IAWSS3BucketClientOptions options)
         {
             if (!string.IsNullOrWhiteSpace(options.Endpoint))
             {

--- a/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCache.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCache.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.Extensions.Options;
-using SixLabors.ImageSharp.Web.Providers.AWS;
 using SixLabors.ImageSharp.Web.Resolvers;
 using SixLabors.ImageSharp.Web.Resolvers.AWS;
 
@@ -25,10 +24,10 @@ namespace SixLabors.ImageSharp.Web.Caching.AWS
         /// Initializes a new instance of the <see cref="AWSS3StorageCache"/> class.
         /// </summary>
         /// <param name="cacheOptions">The cache options.</param>
-        public AWSS3StorageCache(IOptions<AWSS3BucketClientOptions> cacheOptions)
+        public AWSS3StorageCache(IOptions<AWSS3StorageCacheOptions> cacheOptions)
         {
             Guard.NotNull(cacheOptions, nameof(cacheOptions));
-            AWSS3BucketClientOptions options = cacheOptions.Value;
+            AWSS3StorageCacheOptions options = cacheOptions.Value;
             this.bucket = options.BucketName;
             this.amazonS3Client = AmazonS3ClientFactory.CreateClient(options);
         }
@@ -85,12 +84,12 @@ namespace SixLabors.ImageSharp.Web.Caching.AWS
         /// created bucket. If the container already exists, <see langword="null"/>.
         /// </returns>
         public static PutBucketResponse CreateIfNotExists(
-            AWSS3BucketClientOptions options,
+            AWSS3StorageCacheOptions options,
             S3CannedACL acl)
             => AsyncHelper.RunSync(() => CreateIfNotExistsAsync(options, acl));
 
         private static async Task<PutBucketResponse> CreateIfNotExistsAsync(
-            AWSS3BucketClientOptions options,
+            AWSS3StorageCacheOptions options,
             S3CannedACL acl)
         {
             AmazonS3Client client = AmazonS3ClientFactory.CreateClient(options);

--- a/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCacheOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Web.Caching.AWS
+{
+    /// <summary>
+    /// Configuration options for the <see cref="AWSS3StorageCache"/> provider.
+    /// </summary>
+    public class AWSS3StorageCacheOptions : IAWSS3BucketClientOptions
+    {
+        /// <inheritdoc/>
+        public string Region { get; set; }
+
+        /// <inheritdoc/>
+        public string BucketName { get; set; }
+
+        /// <inheritdoc/>
+        public string AccessKey { get; set; }
+
+        /// <inheritdoc/>
+        public string AccessSecret { get; set; }
+
+        /// <inheritdoc/>
+        public string Endpoint { get; set; }
+    }
+}

--- a/src/ImageSharp.Web.Providers.AWS/IAWSS3BucketClientOptions.cs
+++ b/src/ImageSharp.Web.Providers.AWS/IAWSS3BucketClientOptions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Web
+{
+    /// <summary>
+    /// Provides a common interface for AWS S3 Bucket Client Options.
+    /// </summary>
+    internal interface IAWSS3BucketClientOptions
+    {
+        /// <summary>
+        /// Gets or sets the AWS region endpoint (us-east-1/us-west-1/ap-southeast-2).
+        /// </summary>
+        string Region { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AWS bucket name.
+        /// </summary>
+        string BucketName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AWS key - Can be used to override keys provided by the environment.
+        /// If deploying inside an EC2 instance AWS keys will already be available via environment
+        /// variables and don't need to be specified. Follow AWS best security practices on  <see href="https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html"/>.
+        /// </summary>
+        string AccessKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AWS secret - Can be used to override keys provided by the environment.
+        /// If deploying inside an EC2 instance AWS keys will already be available via environment
+        /// variables and don't need to be specified. Follow AWS best security practices on  <see href="https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html"/>.
+        /// </summary>
+        string AccessSecret { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AWS endpoint - used for testing to over region endpoint allowing it
+        /// to be set to localhost.
+        /// </summary>
+        string Endpoint { get; set; }
+    }
+}

--- a/src/ImageSharp.Web.Providers.AWS/Providers/AWSS3StorageImageProviderOptions.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Providers/AWSS3StorageImageProviderOptions.cs
@@ -19,36 +19,21 @@ namespace SixLabors.ImageSharp.Web.Providers.AWS
     /// <summary>
     /// Configuration options for the <see cref="AWSS3StorageImageProvider"/> provider.
     /// </summary>
-    public class AWSS3BucketClientOptions
+    public class AWSS3BucketClientOptions : IAWSS3BucketClientOptions
     {
-        /// <summary>
-        /// Gets or sets the AWS region endpoint (us-east-1/us-west-1/ap-southeast-2).
-        /// </summary>
+        /// <inheritdoc/>
         public string Region { get; set; }
 
-        /// <summary>
-        /// Gets or sets the AWS bucket name.
-        /// </summary>
+        /// <inheritdoc/>
         public string BucketName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the AWS key - Can be used to override keys provided by the environment.
-        /// If deploying inside an EC2 instance AWS keys will already be available via environment
-        /// variables and don't need to be specified. Follow AWS best security practices on  <see href="https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public string AccessKey { get; set; }
 
-        /// <summary>
-        /// Gets or sets the AWS secret - Can be used to override keys provided by the environment.
-        /// If deploying inside an EC2 instance AWS keys will already be available via environment
-        /// variables and don't need to be specified. Follow AWS best security practices on  <see href="https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html"/>.
-        /// </summary>
+        /// <inheritdoc/>
         public string AccessSecret { get; set; }
 
-        /// <summary>
-        /// Gets or sets the AWS endpoint - used for testing to over region endpoint allowing it
-        /// to be set to localhost.
-        /// </summary>
+        /// <inheritdoc/>
         public string Endpoint { get; set; }
     }
 }

--- a/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
@@ -6,19 +6,12 @@ namespace SixLabors.ImageSharp.Web.Caching.Azure
     /// <summary>
     /// Configuration options for the <see cref="AzureBlobStorageCache"/>.
     /// </summary>
-    public class AzureBlobStorageCacheOptions
+    public class AzureBlobStorageCacheOptions : IAzureBlobContainerClientOptions
     {
-        /// <summary>
-        /// Gets or sets the Azure Blob Storage connection string.
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string."/>
-        /// </summary>
+        /// <inheritdoc/>
         public string ConnectionString { get; set; }
 
-        /// <summary>
-        /// Gets or sets the Azure Blob Storage container name.
-        /// Must conform to Azure Blob Storage containiner naming guidlines.
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names"/>
-        /// </summary>
+        /// <inheritdoc/>
         public string ContainerName { get; set; }
     }
 }

--- a/src/ImageSharp.Web.Providers.Azure/IAzureBlobContainerClientOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/IAzureBlobContainerClientOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.ImageSharp.Web
+{
+    /// <summary>
+    /// Provides a common interface for Azure Blob Container Options.
+    /// </summary>
+    internal interface IAzureBlobContainerClientOptions
+    {
+        /// <summary>
+        /// Gets or sets the Azure Blob Storage connection string.
+        /// <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string."/>
+        /// </summary>
+        public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Azure Blob Storage container name.
+        /// Must conform to Azure Blob Storage container naming guidlines.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names"/>
+        /// </summary>
+        public string ContainerName { get; set; }
+    }
+}

--- a/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Providers/AzureBlobStorageImageProviderOptions.cs
@@ -19,19 +19,12 @@ namespace SixLabors.ImageSharp.Web.Providers.Azure
     /// <summary>
     /// Represents a single Azure Blob Storage connection and container.
     /// </summary>
-    public class AzureBlobContainerClientOptions
+    public class AzureBlobContainerClientOptions : IAzureBlobContainerClientOptions
     {
-        /// <summary>
-        /// Gets or sets the Azure Blob Storage connection string.
-        /// <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string."/>
-        /// </summary>
+        /// <inheritdoc/>
         public string ConnectionString { get; set; }
 
-        /// <summary>
-        /// Gets or sets the Azure Blob Storage container name.
-        /// Must conform to Azure Blob Storage containiner naming guidlines.
-        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names"/>
-        /// </summary>
+        /// <inheritdoc/>
         public string ContainerName { get; set; }
     }
 }

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AWSS3StorageCacheTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AWSS3StorageCacheTestServerFixture.cs
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
                 .AddProvider(AWSS3StorageImageProviderFactory.Create)
                 .AddProvider<PhysicalFileSystemProvider>()
                 .AddProcessor<CacheBusterWebProcessor>()
-                .Configure<AWSS3BucketClientOptions>(options =>
+                .Configure<AWSS3StorageCacheOptions>(options =>
                 {
                     options.Endpoint = TestConstants.AWSEndpoint;
                     options.BucketName = TestConstants.AWSCacheBucketName;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
While the options types share the same properties, it's important to maintain separate options classes to allow further extensibility and simplify json configuration.

<!-- Thanks for contributing to ImageSharp! -->
