### PR TITLE
Apply updates to XY and Anchor positions based on EXIF metadata

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# How to contribute to ImageSharp.Web
+# How to contribute to SixLabors.ImageSharp.Web
 
 #### **Did you find a bug?**
 
@@ -16,20 +16,18 @@
 
 #### **Do you intend to add a new feature or change an existing one?**
 
-* Suggest your change in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General) and start writing code.
+* Suggest your change in the [Ideas Discussions Channel](https://github.com/SixLabors/ImageSharp.Web/discussions?discussions_q=category%3AIdeas) and start writing code.
 
 * Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
 
 #### **Do you have questions about consuming the library or the source code?**
 
-* Ask any question about how to use ImageSharp in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General).
+* Ask any question about how to use SixLabors.ImageSharp.Web in the [Help Discussions Channel](https://github.com/SixLabors/ImageSharp.Web/discussions?discussions_q=category%3AHelp).
 
-#### Code of Conduct
+#### Code of Conduct  
 This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org/) to clarify expected behavior in our community.
 For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
-And please remember. ImageSharp.Web is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible imageprocessing available to all. Open Source can only exist with your help.
+And please remember. SixLabors.ImageSharp.Web is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible image processing available to all. Open Source can only exist with your help.
 
 Thanks for reading!
-
-James Jackson-South :heart:

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_0.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_0.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3647bab10b48f496c36770da4d18c161b49b5035e391111df1568c0cd488144f
+size 349915

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_1.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23b1b0eac8c5ee5ae0373d07984b8d57df152e6be363d2ab77b304285bcad81
+size 347327

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_2.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fdadb01889abd7df4bfd24c4c3e9d12017ae8d9b21851fcabd4279f9500f925
+size 349209

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_3.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b151bf11b88398f7358a3a74bf8b7f96b9e436f3d4bb2f86034d1c412039d2d3
+size 348796

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_4.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74e91f96c3b9464890a82650043f6a53dd141167854f8197b3f7997ba0e6fcc9
+size 348052

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_5.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fbfecd9244a37dd0826df446de84365295ad14d592ab7e6d1bf8b73fc364cff
+size 351275

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_6.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b344e9f0c869d8637ea22e672df9451d8d3cc1d2d0b291af3b284e538e5f124
+size 352727

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_7.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a502346769a6adcf0a2f01bc20454eee008fbe859b7f31be29557a1a50f90a98
+size 351856

--- a/samples/ImageSharp.Web.Sample/wwwroot/Landscape_8.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Landscape_8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b89a4185fc8b8daa9313cb29957fc950e903e11714519af18862fb67417c39c2
+size 352067

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_0.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_0.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4294fb393eda895da8a9462ead3391d55daf4ec424fb3ec4bf1d8ef3449947aa
+size 248531

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_1.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8247813c4cedbfcbec5205963655cce449a0286399c5a0128fae4dc9ec50ce
+size 245684

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_2.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a673062f30e7d39f50d0568abf6fe26430831bbc6d4154f28dc67c444d31ace5
+size 246915

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_3.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ca468a3be28da2dc6b0f6701c12dcd9be3c7ef37eb5425187b2ca3ef542ba5
+size 247276

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_4.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de5acdae6b89e635f6bf7d6da8a53fd8a1759b3319951b9d545d3fc839b97833
+size 246554

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_5.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:468714af3b15d491e4de6a48d491404ad45956fb2e28ed6deaf6a3e47f488b14
+size 251487

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_6.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb1f8c59199fc7d27361cb1bb9b82cb91f77cc0bd2934be516bcebb2e2eb9d33
+size 251800

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_7.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d5de444365e3ff99c6c92fbe1db3034b535fb0fef14d8bc3f56f43b616269c2
+size 250892

--- a/samples/ImageSharp.Web.Sample/wwwroot/Portrait_8.jpg
+++ b/samples/ImageSharp.Web.Sample/wwwroot/Portrait_8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66b38ab2c7fbd6850d5a5d2aa953b144acd8226056ee5b7fa2355d4d90c015eb
+size 251978

--- a/samples/ImageSharp.Web.Sample/wwwroot/index.html
+++ b/samples/ImageSharp.Web.Sample/wwwroot/index.html
@@ -24,6 +24,9 @@
       display: flex;
       flex-wrap: wrap;
     }
+      section > p {
+        flex: 0 0 100%;
+      }
 
       section > div {
         flex: 0 0 50%;
@@ -262,6 +265,738 @@
         <p>
           <img src="imagesharp-logo.png?width=123" />
         </p>
+      </div>
+    </section>
+    <section>
+      <h2>EXIF Handling Portrait</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
+      <div>
+        <p>
+          <code>Portrait_0.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_1.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_2.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_3.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_4.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_5.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling Portrait</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
+      <div>
+        <p>
+          <code>Portrait_0.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_1.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_2.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_3.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_4.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_5.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&ranchor=bottomleft</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&ranchor=bottomleft" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling Portrait</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
+      <div>
+        <p>
+          <code>Portrait_0.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_1.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_2.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_3.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_4.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_5.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&ranchor=left&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&ranchor=left&rmode=pad" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling Portrait</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
+      <div>
+        <p>
+          <code>Portrait_0.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_1.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_2.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_3.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_4.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_5.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling Portrait</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
+      <div>
+        <p>
+          <code>Portrait_0.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_1.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_2.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_3.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_4.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_5.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&ranchor=right&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&ranchor=right&rmode=pad" /></p>
+      </div>
+    </section>
+
+
+    <section>
+      <h2>EXIF Handling Portrait</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
+      <div>
+        <p>
+          <code>Portrait_0.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_1.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_2.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_3.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_4.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_5.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&ranchor=bottomright&rmode=pad</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&ranchor=bottomright&rmode=pad" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling : Landscape</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
+      <div>
+        <p>
+          <code>Landscape_0.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_1.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_2.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_3.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_4.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_5.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&rxy=25,25</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&rxy=25,25" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling : Landscape</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
+      <div>
+        <p>
+          <code>Landscape_0.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_1.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_2.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_3.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_4.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_5.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&ranchor=topright</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&ranchor=topright" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling : Landscape</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
+      <div>
+        <p>
+          <code>Landscape_0.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_1.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_2.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_3.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_4.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_5.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&ranchor=top&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&ranchor=top&rmode=pad" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling : Landscape</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
+      <div>
+        <p>
+          <code>Landscape_0.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_1.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_2.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_3.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_4.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_5.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&ranchor=topright&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&ranchor=topright&rmode=pad" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling : Landscape</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
+      <div>
+        <p>
+          <code>Landscape_0.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_1.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_2.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_3.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_4.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_5.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&ranchor=bottom&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&ranchor=bottom&rmode=pad" /></p>
+      </div>
+    </section>
+
+    <section>
+      <h2>EXIF Handling : Landscape</h2>
+      <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
+      <div>
+        <p>
+          <code>Landscape_0.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_1.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_2.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_3.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_4.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_5.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&ranchor=bottomleft&rmode=pad" /></p>
       </div>
     </section>
   </main>

--- a/samples/ImageSharp.Web.Sample/wwwroot/index.html
+++ b/samples/ImageSharp.Web.Sample/wwwroot/index.html
@@ -272,59 +272,59 @@
       <p>Demonstrates that the middleware handles EXIF orientation correctly for portrait images.</p>
       <div>
         <p>
-          <code>Portrait_0.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Portrait_0.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Portrait_0.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Portrait_0.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Portrait_1.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Portrait_1.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Portrait_1.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Portrait_1.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Portrait_2.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Portrait_2.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Portrait_2.jpg?width=60&height=50&rxy=25,25" /></p>
-      </div>
-
-      <div>
-        <p>
-          <code>Portrait_3.jpg?width=60&height=50&rxy=25,25</code>
-        </p>
-        <p><img src="Portrait_3.jpg?width=60&height=50&rxy=25,25" /></p>
-      </div>
-      <div>
-        <p>
-          <code>Portrait_4.jpg?width=60&height=50&rxy=25,25</code>
-        </p>
-        <p><img src="Portrait_4.jpg?width=60&height=50&rxy=25,25" /></p>
-      </div>
-      <div>
-        <p>
-          <code>Portrait_5.jpg?width=60&height=50&rxy=25,25</code>
-        </p>
-        <p><img src="Portrait_5.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Portrait_2.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
 
       <div>
         <p>
-          <code>Portrait_6.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Portrait_3.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Portrait_6.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Portrait_3.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Portrait_7.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Portrait_4.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Portrait_7.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Portrait_4.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Portrait_8.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Portrait_5.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Portrait_8.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Portrait_5.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Portrait_6.jpg?width=60&height=50&rxy=0.25,0.25</code>
+        </p>
+        <p><img src="Portrait_6.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_7.jpg?width=60&height=50&rxy=0.25,0.25</code>
+        </p>
+        <p><img src="Portrait_7.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Portrait_8.jpg?width=60&height=50&rxy=0.25,0.25</code>
+        </p>
+        <p><img src="Portrait_8.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
     </section>
 
@@ -639,59 +639,59 @@
       <p>Demonstrates that the middleware handles EXIF orientation correctly for landscape images.</p>
       <div>
         <p>
-          <code>Landscape_0.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Landscape_0.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Landscape_0.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Landscape_0.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Landscape_1.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Landscape_1.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Landscape_1.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Landscape_1.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Landscape_2.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Landscape_2.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Landscape_2.jpg?width=60&height=50&rxy=25,25" /></p>
-      </div>
-
-      <div>
-        <p>
-          <code>Landscape_3.jpg?width=60&height=50&rxy=25,25</code>
-        </p>
-        <p><img src="Landscape_3.jpg?width=60&height=50&rxy=25,25" /></p>
-      </div>
-      <div>
-        <p>
-          <code>Landscape_4.jpg?width=60&height=50&rxy=25,25</code>
-        </p>
-        <p><img src="Landscape_4.jpg?width=60&height=50&rxy=25,25" /></p>
-      </div>
-      <div>
-        <p>
-          <code>Landscape_5.jpg?width=60&height=50&rxy=25,25</code>
-        </p>
-        <p><img src="Landscape_5.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Landscape_2.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
 
       <div>
         <p>
-          <code>Landscape_6.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Landscape_3.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Landscape_6.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Landscape_3.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Landscape_7.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Landscape_4.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Landscape_7.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Landscape_4.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
       <div>
         <p>
-          <code>Landscape_8.jpg?width=60&height=50&rxy=25,25</code>
+          <code>Landscape_5.jpg?width=60&height=50&rxy=0.25,0.25</code>
         </p>
-        <p><img src="Landscape_8.jpg?width=60&height=50&rxy=25,25" /></p>
+        <p><img src="Landscape_5.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
+      </div>
+
+      <div>
+        <p>
+          <code>Landscape_6.jpg?width=60&height=50&rxy=0.25,0.25</code>
+        </p>
+        <p><img src="Landscape_6.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_7.jpg?width=60&height=50&rxy=0.25,0.25</code>
+        </p>
+        <p><img src="Landscape_7.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
+      </div>
+      <div>
+        <p>
+          <code>Landscape_8.jpg?width=60&height=50&rxy=0.25,0.25</code>
+        </p>
+        <p><img src="Landscape_8.jpg?width=60&height=50&rxy=0.25,0.25" /></p>
       </div>
     </section>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,7 +21,7 @@
     <PackageReference Update="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Update="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Update="SixLabors.ImageSharp"  Version="2.0.0-alpha.0.172" />
+    <PackageReference Update="SixLabors.ImageSharp"  Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Web
@@ -96,6 +97,45 @@ namespace SixLabors.ImageSharp.Web
         /// </summary>
         /// <param name="destination">The destination stream.</param>
         public void Save(Stream destination) => this.Image.Save(destination, this.encoder);
+
+        /// <summary>
+        /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation"/>
+        /// indicating that the image is rotated (not flipped).
+        /// </summary>
+        /// <param name="orientation">The captured orientation. Use <see cref="ExifOrientationMode"/> for comparison.</param>
+        /// <returns>The <see cref="bool"/> indicating whether the image contains EXIF metadata indicating that the image is rotated.</returns>
+        public bool IsExifRotated(out ushort orientation)
+        {
+            orientation = ExifOrientationMode.Unknown;
+            if (this.Image.Metadata.ExifProfile != null)
+            {
+                IExifValue<ushort> value = this.Image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
+                if (value is null)
+                {
+                    return false;
+                }
+
+                if (value.DataType == ExifDataType.Short)
+                {
+                    orientation = value.Value;
+                }
+                else
+                {
+                    orientation = Convert.ToUInt16(value.Value);
+                }
+
+                return orientation switch
+                {
+                    ExifOrientationMode.LeftTop
+                    or ExifOrientationMode.RightTop
+                    or ExifOrientationMode.RightBottom
+                    or ExifOrientationMode.LeftBottom => true,
+                    _ => false,
+                };
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -111,11 +111,12 @@ namespace SixLabors.ImageSharp.Web
         /// <param name="destination">The destination stream.</param>
         public void Save(Stream destination) => this.Image.Save(destination, this.encoder);
 
+        /// <summary>
         /// Saves image to the specified destination stream.
         /// </summary>
         /// <param name="destination">The destination stream.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task SaveAsync(Stream destination) => await this.Image.SaveAsync(destination, this.encoder);
+        public Task SaveAsync(Stream destination) => this.Image.SaveAsync(destination, this.encoder);
 
         /// <summary>
         /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation"/>

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -102,7 +102,7 @@ namespace SixLabors.ImageSharp.Web
         /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation"/>
         /// indicating that the image is rotated (not flipped).
         /// </summary>
-        /// <param name="orientation">The captured orientation. Use <see cref="ExifOrientationMode"/> for comparison.</param>
+        /// <param name="orientation">The decoded orientation. Use <see cref="ExifOrientationMode"/> for comparison.</param>
         /// <returns>The <see cref="bool"/> indicating whether the image contains EXIF metadata indicating that the image is rotated.</returns>
         public bool IsExifRotated(out ushort orientation)
         {

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -119,39 +119,38 @@ namespace SixLabors.ImageSharp.Web
         public Task SaveAsync(Stream destination) => this.Image.SaveAsync(destination, this.encoder);
 
         /// <summary>
-        /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation"/>
-        /// indicating that the image is rotated (not flipped).
+        /// Gets the EXIF orientation metata for the <see cref="FormattedImage"/>.
         /// </summary>
-        /// <param name="orientation">The decoded orientation. Use <see cref="ExifOrientationMode"/> for comparison.</param>
-        /// <returns>The <see cref="bool"/> indicating whether the image contains EXIF metadata indicating that the image is rotated.</returns>
-        public bool IsExifRotated(out ushort orientation)
+        /// <param name="value">
+        /// When this method returns, contains the value parsed from decoded EXIF metadata; otherwise,
+        /// the default value for the type of the <paramref name="value"/> parameter.
+        /// This parameter is passed uninitialized. Use <see cref="ExifOrientationMode"/> for comparison.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the <see cref="FormattedImage"/> contains EXIF orientation metadata
+        /// for <see cref="ExifTag.Orientation"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool TryGetExifOrientation(out ushort value)
         {
-            orientation = ExifOrientationMode.Unknown;
+            value = ExifOrientationMode.Unknown;
             if (this.Image.Metadata.ExifProfile != null)
             {
-                IExifValue<ushort> value = this.Image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
-                if (value is null)
+                IExifValue<ushort> orientation = this.Image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
+                if (orientation is null)
                 {
                     return false;
                 }
 
-                if (value.DataType == ExifDataType.Short)
+                if (orientation.DataType == ExifDataType.Short)
                 {
-                    orientation = value.Value;
+                    value = orientation.Value;
                 }
                 else
                 {
-                    orientation = Convert.ToUInt16(value.Value);
+                    value = Convert.ToUInt16(orientation.Value);
                 }
 
-                return orientation switch
-                {
-                    ExifOrientationMode.LeftTop
-                    or ExifOrientationMode.RightTop
-                    or ExifOrientationMode.RightBottom
-                    or ExifOrientationMode.LeftBottom => true,
-                    _ => false,
-                };
+                return true;
             }
 
             return false;

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -32,13 +31,13 @@ namespace SixLabors.ImageSharp.Web.Middleware
         /// Used to temporarily store source metadata reads to reduce the overhead of cache lookups.
         /// </summary>
         private static readonly ConcurrentTLruCache<string, ImageMetadata> SourceMetadataLru
-            = new(1024, TimeSpan.FromMinutes(5));
+            = new(1024, TimeSpan.FromSeconds(30));
 
         /// <summary>
         /// Used to temporarily store cache resolver reads to reduce the overhead of cache lookups.
         /// </summary>
         private static readonly ConcurrentTLruCache<string, (IImageCacheResolver, ImageCacheMetadata)> CacheResolverLru
-            = new(1024, TimeSpan.FromMinutes(5));
+            = new(1024, TimeSpan.FromSeconds(30));
 
         /// <summary>
         /// The function processing the Http request.

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -80,7 +80,7 @@ namespace SixLabors.ImageSharp.Web.Processors
             CommandParser parser,
             CultureInfo culture)
         {
-            ResizeOptions options = GetResizeOptions(image.Image, commands, parser, culture);
+            ResizeOptions options = GetResizeOptions(image, commands, parser, culture);
 
             if (options != null)
             {
@@ -90,8 +90,18 @@ namespace SixLabors.ImageSharp.Web.Processors
             return image;
         }
 
-        private static ResizeOptions GetResizeOptions(
-            Image image,
+        /// <summary>
+        /// Parses the command collection returning the resize options.
+        /// </summary>
+        /// <param name="image">The image to process.</param>
+        /// <param name="commands">The ordered collection containing the processing commands.</param>
+        /// <param name="parser">The command parser use for parting commands.</param>
+        /// <param name="culture">
+        /// The <see cref="CultureInfo"/> to use as the current parsing culture.
+        /// </param>
+        /// <returns>The <see cref="ResizeOptions"/>.</returns>
+        internal static ResizeOptions GetResizeOptions(
+            FormattedImage image,
             CommandCollection commands,
             CommandParser parser,
             CultureInfo culture)
@@ -101,18 +111,20 @@ namespace SixLabors.ImageSharp.Web.Processors
                 return null;
             }
 
-            Size size = ParseSize(image, commands, parser, culture);
+            bool rotated = ShouldHandleExifRotation(image, commands, parser, culture, out ushort orientation);
+
+            Size size = ParseSize(rotated, commands, parser, culture);
 
             if (size.Width <= 0 && size.Height <= 0)
             {
                 return null;
             }
 
-            var options = new ResizeOptions
+            ResizeOptions options = new()
             {
                 Size = size,
-                CenterCoordinates = GetCenter(commands, parser, culture),
-                Position = GetAnchor(commands, parser, culture),
+                CenterCoordinates = GetCenter(rotated, commands, parser, culture),
+                Position = GetAnchor(orientation, commands, parser, culture),
                 Mode = GetMode(commands, parser, culture),
                 Compand = GetCompandMode(commands, parser, culture),
             };
@@ -124,7 +136,7 @@ namespace SixLabors.ImageSharp.Web.Processors
         }
 
         private static Size ParseSize(
-            Image image,
+            bool rotated,
             CommandCollection commands,
             CommandParser parser,
             CultureInfo culture)
@@ -132,35 +144,11 @@ namespace SixLabors.ImageSharp.Web.Processors
             // The command parser will reject negative numbers as it clamps values to ranges.
             int width = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Width), culture);
             int height = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Height), culture);
-
-            // Browsers now implement 'image-orientation: from-image' by default.
-            // https://developer.mozilla.org/en-US/docs/web/css/image-orientation
-            // This makes orientation handling confusing for users who expect images to be resized in accordance
-            // to what they observe rather than pure (and correct) methods.
-            //
-            // To accomodate this we parse the dimensions to use based upon decoded EXIF orientation values, switching
-            // the width/height parameters when images are rotated (not flipped).
-            // We default to 'true' for EXIF orientation handling. By passing 'false' it can be turned off.
-            if (!commands.Contains(Orient) || parser.ParseValue<bool>(commands.GetValueOrDefault(Orient), culture))
-            {
-                if (image.Metadata.ExifProfile != null)
-                {
-                    IExifValue<ushort> orientation = image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
-                    return orientation.Value switch
-                    {
-                        ExifOrientationMode.LeftTop
-                        or ExifOrientationMode.RightTop
-                        or ExifOrientationMode.RightBottom
-                        or ExifOrientationMode.LeftBottom => new Size(height, width),
-                        _ => new Size(width, height),
-                    };
-                }
-            }
-
-            return new Size(width, height);
+            return rotated ? new Size(height, width) : new Size(width, height);
         }
 
         private static PointF? GetCenter(
+            bool rotated,
             CommandCollection commands,
             CommandParser parser,
             CultureInfo culture)
@@ -172,7 +160,7 @@ namespace SixLabors.ImageSharp.Web.Processors
                 return null;
             }
 
-            return new PointF(coordinates[0], coordinates[1]);
+            return rotated ? new PointF(coordinates[1], coordinates[0]) : new PointF(coordinates[0], coordinates[1]);
         }
 
         private static ResizeMode GetMode(
@@ -182,10 +170,79 @@ namespace SixLabors.ImageSharp.Web.Processors
             => parser.ParseValue<ResizeMode>(commands.GetValueOrDefault(Mode), culture);
 
         private static AnchorPositionMode GetAnchor(
+            ushort orientation,
             CommandCollection commands,
             CommandParser parser,
             CultureInfo culture)
-            => parser.ParseValue<AnchorPositionMode>(commands.GetValueOrDefault(Anchor), culture);
+        {
+            AnchorPositionMode anchor = parser.ParseValue<AnchorPositionMode>(commands.GetValueOrDefault(Anchor), culture);
+            if (orientation is >= ExifOrientationMode.Unknown and <= ExifOrientationMode.TopLeft)
+            {
+                return anchor;
+            }
+
+            return anchor switch
+            {
+                AnchorPositionMode.Center => anchor,
+                AnchorPositionMode.Top => orientation switch
+                {
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Left,
+                    ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Right,
+                    _ => anchor,
+                },
+                AnchorPositionMode.Bottom => orientation switch
+                {
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Top,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Right,
+                    ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Left,
+                    _ => anchor,
+                },
+                AnchorPositionMode.Left => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Right,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Top,
+                    _ => anchor,
+                },
+                AnchorPositionMode.Right => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Left,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
+                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
+                    _ => anchor,
+                },
+                AnchorPositionMode.TopLeft => orientation switch
+                {
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
+                    ExifOrientationMode.TopRight or ExifOrientationMode.RightBottom => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
+                    _ => anchor,
+                },
+                AnchorPositionMode.TopRight => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.LeftTop => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.BottomRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomLeft,
+                    _ => anchor,
+                },
+                AnchorPositionMode.BottomRight => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.RightBottom => AnchorPositionMode.BottomLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
+                    _ => anchor,
+                },
+                AnchorPositionMode.BottomLeft => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomRight,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
+                    _ => anchor,
+                },
+                _ => anchor,
+            };
+        }
 
         private static bool GetCompandMode(
             CommandCollection commands,
@@ -221,6 +278,25 @@ namespace SixLabors.ImageSharp.Web.Processors
             }
 
             return KnownResamplers.Bicubic;
+        }
+
+        private static bool ShouldHandleExifRotation(FormattedImage image, CommandCollection commands, CommandParser parser, CultureInfo culture, out ushort orientation)
+        {
+            // Browsers now implement 'image-orientation: from-image' by default.
+            // https://developer.mozilla.org/en-US/docs/web/css/image-orientation
+            // This makes orientation handling confusing for users who expect images to be resized in accordance
+            // to what they observe rather than pure (and correct) methods.
+            //
+            // To accomodate this we parse the dimensions to use based upon decoded EXIF orientation values, switching
+            // the width/height parameters when images are rotated (not flipped).
+            // We default to 'true' for EXIF orientation handling. By passing 'false' it can be turned off.
+            if (commands.Contains(Orient) && !parser.ParseValue<bool>(commands.GetValueOrDefault(Orient), culture))
+            {
+                orientation = ExifOrientationMode.Unknown;
+                return false;
+            }
+
+            return image.IsExifRotated(out orientation);
         }
     }
 }

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -180,23 +180,26 @@ namespace SixLabors.ImageSharp.Web.Processors
                     break;
                 case ExifOrientationMode.BottomRight:
                     builder.AppendRotationDegrees(180);
+                    builder.AppendTranslation(new PointF(0, -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.BottomLeft:
-                    builder.AppendTranslation(new PointF(0, size.Height - center.Y));
+                    builder.AppendRotationDegrees(180);
+                    builder.AppendTranslation(new PointF(size.Width - center.X, -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.LeftTop:
                     builder.AppendRotationDegrees(90);
                     builder.AppendTranslation(new PointF(size.Width - center.X, 0));
                     break;
                 case ExifOrientationMode.RightTop:
-                    builder.AppendRotationDegrees(90);
+                    builder.AppendRotationDegrees(270);
                     break;
                 case ExifOrientationMode.RightBottom:
-                    builder.AppendTranslation(new PointF(0, size.Height - center.Y));
                     builder.AppendRotationDegrees(270);
+                    builder.AppendTranslation(new PointF(-(size.Width - center.X), -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.LeftBottom:
-                    builder.AppendRotationDegrees(270);
+                    builder.AppendRotationDegrees(90);
+                    builder.AppendTranslation(new PointF(-(size.Width - center.X), 0));
                     break;
                 default:
                     return center;
@@ -262,16 +265,16 @@ namespace SixLabors.ImageSharp.Web.Processors
                 },
                 AnchorPositionMode.Left => orientation switch
                 {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomLeft => AnchorPositionMode.Right,
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Right,
                     ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
                     ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
                     _ => anchor,
                 },
                 AnchorPositionMode.Right => orientation switch
                 {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomLeft => AnchorPositionMode.Left,
-                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
-                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Left,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Top,
                     _ => anchor,
                 },
                 AnchorPositionMode.TopLeft => orientation switch
@@ -291,15 +294,15 @@ namespace SixLabors.ImageSharp.Web.Processors
                 AnchorPositionMode.BottomRight => orientation switch
                 {
                     ExifOrientationMode.TopRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomLeft,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
                     _ => anchor,
                 },
                 AnchorPositionMode.BottomLeft => orientation switch
                 {
                     ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomRight,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
                     _ => anchor,
                 },
                 _ => anchor,

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -124,7 +124,7 @@ namespace SixLabors.ImageSharp.Web.Processors
             ResizeOptions options = new()
             {
                 Size = size,
-                CenterCoordinates = GetCenter(image, orientation, commands, parser, culture),
+                CenterCoordinates = GetCenter(orientation, commands, parser, culture),
                 Position = GetAnchor(orientation, commands, parser, culture),
                 Mode = GetMode(commands, parser, culture),
                 Compand = GetCompandMode(commands, parser, culture),
@@ -152,7 +152,6 @@ namespace SixLabors.ImageSharp.Web.Processors
         }
 
         private static PointF? GetCenter(
-            FormattedImage image,
             ushort orientation,
             CommandCollection commands,
             CommandParser parser,
@@ -171,11 +170,10 @@ namespace SixLabors.ImageSharp.Web.Processors
                 return center;
             }
 
-            AffineTransformBuilder builder = new();
-            Size size = image.Image.Size();
-
             // New XY is calculated based on flipping and rotating the input XY.
-            // Operations are based upon AutoOrientProcessor implementation.
+            // Coordinates range from 0-1, hence the matching source size.
+            AffineTransformBuilder builder = new();
+            Size size = new(1, 1);
             switch (orientation)
             {
                 case ExifOrientationMode.TopRight:
@@ -183,26 +181,23 @@ namespace SixLabors.ImageSharp.Web.Processors
                     break;
                 case ExifOrientationMode.BottomRight:
                     builder.AppendRotationDegrees(180);
-                    builder.AppendTranslation(new PointF(0, -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.BottomLeft:
-                    builder.AppendRotationDegrees(180);
-                    builder.AppendTranslation(new PointF(size.Width - center.X, -(size.Height - center.Y)));
+                    builder.AppendTranslation(new PointF(0, size.Height - center.Y));
                     break;
                 case ExifOrientationMode.LeftTop:
-                    builder.AppendRotationDegrees(90);
                     builder.AppendTranslation(new PointF(size.Width - center.X, 0));
+                    builder.AppendRotationDegrees(270);
                     break;
                 case ExifOrientationMode.RightTop:
                     builder.AppendRotationDegrees(270);
                     break;
                 case ExifOrientationMode.RightBottom:
-                    builder.AppendRotationDegrees(270);
-                    builder.AppendTranslation(new PointF(-(size.Width - center.X), -(size.Height - center.Y)));
+                    builder.AppendTranslation(new PointF(size.Width - center.X, 0));
+                    builder.AppendRotationDegrees(90);
                     break;
                 case ExifOrientationMode.LeftBottom:
                     builder.AppendRotationDegrees(90);
-                    builder.AppendTranslation(new PointF(-(size.Width - center.X), 0));
                     break;
                 default:
                     return center;

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -285,8 +285,8 @@ namespace SixLabors.ImageSharp.Web.Processors
                 AnchorPositionMode.TopRight => orientation switch
                 {
                     ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopLeft,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
                     _ => anchor,
                 },
                 AnchorPositionMode.BottomRight => orientation switch

--- a/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
@@ -342,8 +342,8 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
                 AnchorPositionMode.TopRight => orientation switch
                 {
                     ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopLeft,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
                     _ => anchor,
                 },
                 AnchorPositionMode.BottomRight => orientation switch

--- a/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
@@ -271,23 +271,26 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
                     break;
                 case ExifOrientationMode.BottomRight:
                     builder.AppendRotationDegrees(180);
+                    builder.AppendTranslation(new PointF(0, -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.BottomLeft:
-                    builder.AppendTranslation(new PointF(0, size.Height - center.Y));
+                    builder.AppendRotationDegrees(180);
+                    builder.AppendTranslation(new PointF(size.Width - center.X, -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.LeftTop:
                     builder.AppendRotationDegrees(90);
                     builder.AppendTranslation(new PointF(size.Width - center.X, 0));
                     break;
                 case ExifOrientationMode.RightTop:
-                    builder.AppendRotationDegrees(90);
+                    builder.AppendRotationDegrees(270);
                     break;
                 case ExifOrientationMode.RightBottom:
-                    builder.AppendTranslation(new PointF(0, size.Height - center.Y));
                     builder.AppendRotationDegrees(270);
+                    builder.AppendTranslation(new PointF(-(size.Width - center.X), -(size.Height - center.Y)));
                     break;
                 case ExifOrientationMode.LeftBottom:
-                    builder.AppendRotationDegrees(270);
+                    builder.AppendRotationDegrees(90);
+                    builder.AppendTranslation(new PointF(-(size.Width - center.X), 0));
                     break;
                 default:
                     return center;
@@ -317,16 +320,16 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
                 },
                 AnchorPositionMode.Left => orientation switch
                 {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomLeft => AnchorPositionMode.Right,
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Right,
                     ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
                     ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
                     _ => anchor,
                 },
                 AnchorPositionMode.Right => orientation switch
                 {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomLeft => AnchorPositionMode.Left,
-                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
-                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Left,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Top,
                     _ => anchor,
                 },
                 AnchorPositionMode.TopLeft => orientation switch
@@ -346,15 +349,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
                 AnchorPositionMode.BottomRight => orientation switch
                 {
                     ExifOrientationMode.TopRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomLeft,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
                     _ => anchor,
                 },
                 AnchorPositionMode.BottomLeft => orientation switch
                 {
                     ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomRight,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
                     _ => anchor,
                 },
                 _ => anchor,

--- a/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/ResizeWebProcessorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using SixLabors.ImageSharp.Formats.Png;
@@ -78,7 +79,7 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
         [InlineData(ExifOrientationMode.RightTop, true)]
         [InlineData(ExifOrientationMode.RightBottom, true)]
         [InlineData(ExifOrientationMode.LeftBottom, true)]
-        public void ResizeWebProcessor_RespectsOrientation(ushort orientation, bool rotated)
+        public void ResizeWebProcessor_RespectsOrientation_Size(ushort orientation, bool rotated)
         {
             const int width = 4;
             const int height = 6;
@@ -118,6 +119,110 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
             {
                 Assert.Equal(width, image.Width);
                 Assert.Equal(height, image.Height);
+            }
+        }
+
+        [Theory]
+        [InlineData(ExifOrientationMode.Unknown, false)]
+        [InlineData(ExifOrientationMode.TopLeft, false)]
+        [InlineData(ExifOrientationMode.TopRight, false)]
+        [InlineData(ExifOrientationMode.BottomRight, false)]
+        [InlineData(ExifOrientationMode.BottomLeft, false)]
+        [InlineData(ExifOrientationMode.LeftTop, true)]
+        [InlineData(ExifOrientationMode.RightTop, true)]
+        [InlineData(ExifOrientationMode.RightBottom, true)]
+        [InlineData(ExifOrientationMode.LeftBottom, true)]
+        public void ResizeWebProcessor_RespectsOrientation_Center(ushort orientation, bool rotated)
+        {
+            const int width = 4;
+            const int height = 6;
+            const float x = 1;
+            const float y = 2;
+
+            var converters = new List<ICommandConverter>
+            {
+                new IntegralNumberConverter<uint>(),
+                new ArrayConverter<float>(),
+                new EnumConverter(),
+                new SimpleCommandConverter<bool>(),
+                new SimpleCommandConverter<float>()
+            };
+
+            var parser = new CommandParser(converters);
+            CultureInfo culture = CultureInfo.InvariantCulture;
+
+            CommandCollection commands = new()
+            {
+                { new(ResizeWebProcessor.Width, width.ToString()) },
+                { new(ResizeWebProcessor.Height, height.ToString()) },
+                { new(ResizeWebProcessor.Xy, $"{x},{y}") },
+                { new(ResizeWebProcessor.Mode, nameof(ResizeMode.Stretch)) }
+            };
+
+            using var image = new Image<Rgba32>(1, 1);
+            image.Metadata.ExifProfile = new();
+            image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, orientation);
+
+            using var formatted = new FormattedImage(image, PngFormat.Instance);
+
+            ResizeOptions options = ResizeWebProcessor.GetResizeOptions(formatted, commands, parser, culture);
+            PointF xy = options.CenterCoordinates.Value;
+
+            if (rotated)
+            {
+                Assert.Equal(x, xy.Y);
+                Assert.Equal(y, xy.X);
+            }
+            else
+            {
+                Assert.Equal(x, xy.X);
+                Assert.Equal(y, xy.Y);
+            }
+        }
+
+        [Theory]
+        [InlineData(ExifOrientationMode.Unknown)]
+        [InlineData(ExifOrientationMode.TopLeft)]
+        [InlineData(ExifOrientationMode.TopRight)]
+        [InlineData(ExifOrientationMode.BottomRight)]
+        [InlineData(ExifOrientationMode.BottomLeft)]
+        [InlineData(ExifOrientationMode.LeftTop)]
+        [InlineData(ExifOrientationMode.RightTop)]
+        [InlineData(ExifOrientationMode.RightBottom)]
+        [InlineData(ExifOrientationMode.LeftBottom)]
+        public void ResizeWebProcessor_RespectsOrientation_Anchor(ushort orientation)
+        {
+            var converters = new List<ICommandConverter>
+            {
+                new IntegralNumberConverter<uint>(),
+                new ArrayConverter<float>(),
+                new EnumConverter(),
+                new SimpleCommandConverter<bool>(),
+                new SimpleCommandConverter<float>()
+            };
+
+            var parser = new CommandParser(converters);
+            CultureInfo culture = CultureInfo.InvariantCulture;
+
+            using Image<Rgba32> image = new(1, 1);
+            image.Metadata.ExifProfile = new();
+            image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, orientation);
+            using FormattedImage formatted = new(image, PngFormat.Instance);
+
+            foreach (AnchorPositionMode anchor in (AnchorPositionMode[])Enum.GetValues(typeof(AnchorPositionMode)))
+            {
+                CommandCollection commands = new()
+                {
+                    { new(ResizeWebProcessor.Width, 4.ToString()) },
+                    { new(ResizeWebProcessor.Height, 6.ToString()) },
+                    { new(ResizeWebProcessor.Mode, nameof(ResizeMode.Stretch)) },
+                    { new(ResizeWebProcessor.Anchor, anchor.ToString()) },
+                };
+
+                ResizeOptions options = ResizeWebProcessor.GetResizeOptions(formatted, commands, parser, culture);
+
+                AnchorPositionMode expected = GetExpectedAnchor(orientation, anchor);
+                Assert.Equal(expected, options.Position);
             }
         }
 
@@ -166,5 +271,68 @@ namespace SixLabors.ImageSharp.Web.Tests.Processors
             Assert.Equal(width, image.Width);
             Assert.Equal(height, image.Height);
         }
+
+        private static AnchorPositionMode GetExpectedAnchor(ushort orientation, AnchorPositionMode anchor)
+            => anchor switch
+            {
+                AnchorPositionMode.Center => anchor,
+                AnchorPositionMode.Top => orientation switch
+                {
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Left,
+                    ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Right,
+                    _ => anchor,
+                },
+                AnchorPositionMode.Bottom => orientation switch
+                {
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Top,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Right,
+                    ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Left,
+                    _ => anchor,
+                },
+                AnchorPositionMode.Left => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Right,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Bottom,
+                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Top,
+                    _ => anchor,
+                },
+                AnchorPositionMode.Right => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Left,
+                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
+                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
+                    _ => anchor,
+                },
+                AnchorPositionMode.TopLeft => orientation switch
+                {
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
+                    ExifOrientationMode.TopRight or ExifOrientationMode.RightBottom => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
+                    _ => anchor,
+                },
+                AnchorPositionMode.TopRight => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.LeftTop => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.BottomRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomLeft,
+                    _ => anchor,
+                },
+                AnchorPositionMode.BottomRight => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.RightBottom => AnchorPositionMode.BottomLeft,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
+                    _ => anchor,
+                },
+                AnchorPositionMode.BottomLeft => orientation switch
+                {
+                    ExifOrientationMode.TopRight or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomRight,
+                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
+                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
+                    _ => anchor,
+                },
+                _ => anchor,
+            };
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Following on from #217  This PR updates `ResizeWebProcessor` to correctly handle `XY` and `Anchor` commands when processing EXIF orientated images.

There's a lot of work involved in handling this with most of the logic based upon some of the work upstream in ImageSharp when normalizing orientation values. The following [image](https://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/) will help explain the affect on an image each rotation value has.

![image](https://user-images.githubusercontent.com/385879/152723956-e4e3b57e-dcd6-4e67-8754-4c32e2872d4a.png)


cc @ronaldbarendse 

<!-- Thanks for contributing to ImageSharp! -->
