### PR TITLE
Load source images asynchronously to prevent thread pool exhaustion

### DIFF
--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
@@ -92,10 +93,29 @@ namespace SixLabors.ImageSharp.Web
         }
 
         /// <summary>
+        /// Loads the specified source.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="source">The source.</param>
+        /// <returns>A <see cref="Task{FormattedImage}"/> representing the asynchronous operation.</returns>
+        public static async Task<FormattedImage> LoadAsync(Configuration configuration, Stream source)
+        {
+            (Image<Rgba32> image, IImageFormat format) = await ImageSharp.Image.LoadWithFormatAsync<Rgba32>(configuration, source);
+            return new FormattedImage(image, format);
+        }
+
+        /// <summary>
         /// Saves image to the specified destination stream.
         /// </summary>
         /// <param name="destination">The destination stream.</param>
         public void Save(Stream destination) => this.Image.Save(destination, this.encoder);
+
+        /// <summary>
+        /// Saves image to the specified destination stream.
+        /// </summary>
+        /// <param name="destination">The destination stream.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task SaveAsync(Stream destination) => await this.Image.SaveAsync(destination, this.encoder);
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -335,7 +335,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                                 }
                                 else
                                 {
-                                    using var image = FormattedImage.Load(this.options.Configuration, inStream);
+                                    using FormattedImage image = await FormattedImage.LoadAsync(this.options.Configuration, inStream);
 
                                     image.Process(
                                         this.logger,


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
While debugging a memory dump taken during an outage of our production image processing servers, we discovered that nearly all of the thread pool worker threads were blocked waiting on network IO loading source image data, which led to thread pool starvation that was preventing any async work from executing.  This PR addresses the source of the problem by replacing the synchronous `Image.Load()` call with the equivalent async call.