### PR TITLE
Move re-usable orientation logic into OrientationHelper

### DIFF
--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -121,29 +121,33 @@ namespace SixLabors.ImageSharp.Web
         public Task SaveAsync(Stream destination) => this.Image.SaveAsync(destination, this.encoder);
 
         /// <summary>
-        /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation" />.
+        /// Gets the EXIF orientation metata for the <see cref="FormattedImage" />.
         /// </summary>
-        /// <param name="orientation">The decoded orientation. Use <see cref="ExifOrientationMode" /> for comparison.</param>
-        /// <returns>The <see cref="bool"/> indicating whether the image contains EXIF metadata for <see cref="ExifTag.Orientation" />.</returns>
-        public bool TryGetExifOrientation(out ushort orientation)
+        /// <param name="value">When this method returns, contains the value parsed from decoded EXIF metadata;
+        /// otherwise, the default value for the type of the <paramref name="value" /> parameter.
+        /// This parameter is passed uninitialized. Use <see cref="ExifOrientationMode" /> for comparison.</param>
+        /// <returns>
+        /// <see langword="true" /> if the <see cref="FormattedImage" /> contains EXIF orientation metadata
+        /// for <see cref="ExifTag.Orientation" />; otherwise, <see langword="false" />.
+        /// </returns>
+        public bool TryGetExifOrientation(out ushort value)
         {
-            ExifProfile exifProfile = this.Image.Metadata.ExifProfile;
-            if (exifProfile is not null)
+            if (this.Image.Metadata.ExifProfile is ExifProfile exifProfile &&
+                exifProfile.GetValue(ExifTag.Orientation) is IExifValue<ushort> orientation)
             {
-                IExifValue<ushort> value = exifProfile.GetValue(ExifTag.Orientation);
-                if (value.DataType == ExifDataType.Short)
+                if (orientation.DataType == ExifDataType.Short)
                 {
-                    orientation = value.Value;
+                    value = orientation.Value;
                 }
                 else
                 {
-                    orientation = Convert.ToUInt16(value.Value);
+                    value = Convert.ToUInt16(orientation.Value);
                 }
 
                 return true;
             }
 
-            orientation = ExifOrientationMode.Unknown;
+            value = ExifOrientationMode.Unknown;
             return false;
         }
 

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Web
     /// <summary>
     /// A class encapsulating an image with a particular file encoding.
     /// </summary>
-    /// <seealso cref="IDisposable"/>
+    /// <seealso cref="IDisposable" />
     public sealed class FormattedImage : IDisposable
     {
         private readonly ImageFormatManager imageFormatsManager;
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Web
         private IImageEncoder encoder;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FormattedImage"/> class.
+        /// Initializes a new instance of the <see cref="FormattedImage" /> class.
         /// </summary>
         /// <param name="image">The image.</param>
         /// <param name="format">The format.</param>
@@ -70,7 +70,7 @@ namespace SixLabors.ImageSharp.Web
                     ThrowNull(nameof(value));
                 }
 
-                // The given type should match the format encoder.
+                // The given type should match the format encoder
                 IImageEncoder reference = this.imageFormatsManager.FindEncoder(this.Format);
                 if (reference.GetType() != value.GetType())
                 {
@@ -86,10 +86,11 @@ namespace SixLabors.ImageSharp.Web
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="source">The source.</param>
-        /// <returns>The <see cref="FormattedImage"/>.</returns>
+        /// <returns>The <see cref="FormattedImage" />.</returns>
         public static FormattedImage Load(Configuration configuration, Stream source)
         {
             var image = ImageSharp.Image.Load<Rgba32>(configuration, source, out IImageFormat format);
+
             return new FormattedImage(image, format);
         }
 
@@ -98,10 +99,11 @@ namespace SixLabors.ImageSharp.Web
         /// </summary>
         /// <param name="configuration">The configuration.</param>
         /// <param name="source">The source.</param>
-        /// <returns>A <see cref="Task{FormattedImage}"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="Task{FormattedImage}" /> representing the asynchronous operation.</returns>
         public static async Task<FormattedImage> LoadAsync(Configuration configuration, Stream source)
         {
             (Image<Rgba32> image, IImageFormat format) = await ImageSharp.Image.LoadWithFormatAsync<Rgba32>(configuration, source);
+
             return new FormattedImage(image, format);
         }
 
@@ -115,26 +117,20 @@ namespace SixLabors.ImageSharp.Web
         /// Saves image to the specified destination stream.
         /// </summary>
         /// <param name="destination">The destination stream.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
         public Task SaveAsync(Stream destination) => this.Image.SaveAsync(destination, this.encoder);
 
         /// <summary>
-        /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation"/>
-        /// indicating that the image is rotated (not flipped).
+        /// Returns a value indicating whether the source image contains EXIF metadata for <see cref="ExifTag.Orientation" />.
         /// </summary>
-        /// <param name="orientation">The decoded orientation. Use <see cref="ExifOrientationMode"/> for comparison.</param>
-        /// <returns>The <see cref="bool"/> indicating whether the image contains EXIF metadata indicating that the image is rotated.</returns>
-        public bool IsExifRotated(out ushort orientation)
+        /// <param name="orientation">The decoded orientation. Use <see cref="ExifOrientationMode" /> for comparison.</param>
+        /// <returns>The <see cref="bool"/> indicating whether the image contains EXIF metadata for <see cref="ExifTag.Orientation" />.</returns>
+        public bool TryGetExifOrientation(out ushort orientation)
         {
-            orientation = ExifOrientationMode.Unknown;
-            if (this.Image.Metadata.ExifProfile != null)
+            ExifProfile exifProfile = this.Image.Metadata.ExifProfile;
+            if (exifProfile is not null)
             {
-                IExifValue<ushort> value = this.Image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
-                if (value is null)
-                {
-                    return false;
-                }
-
+                IExifValue<ushort> value = exifProfile.GetValue(ExifTag.Orientation);
                 if (value.DataType == ExifDataType.Short)
                 {
                     orientation = value.Value;
@@ -144,22 +140,15 @@ namespace SixLabors.ImageSharp.Web
                     orientation = Convert.ToUInt16(value.Value);
                 }
 
-                return orientation switch
-                {
-                    ExifOrientationMode.LeftTop
-                    or ExifOrientationMode.RightTop
-                    or ExifOrientationMode.RightBottom
-                    or ExifOrientationMode.LeftBottom => true,
-                    _ => false,
-                };
+                return true;
             }
 
+            orientation = ExifOrientationMode.Unknown;
             return false;
         }
 
         /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting
-        /// unmanaged resources.
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()
         {

--- a/src/ImageSharp.Web/OrientationHelper.cs
+++ b/src/ImageSharp.Web/OrientationHelper.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Web.Commands;
+
+namespace SixLabors.ImageSharp.Web
+{
+    /// <summary>
+    /// Helper method for handling orientation parsing/transforms in processors.
+    /// </summary>
+    public static class OrientationHelper
+    {
+        /// <summary>
+        /// The command constant for the orientation handling mode.
+        /// </summary>
+        public const string Command = "orient";
+
+        /// <summary>
+        /// Gets the orientation.
+        /// </summary>
+        /// <param name="image">The image to process.</param>
+        /// <param name="commands">The ordered collection containing the processing commands.</param>
+        /// <param name="parser">The command parser use for parting commands.</param>
+        /// <param name="culture">The <see cref="CultureInfo" /> to use as the current parsing culture.</param>
+        /// <param name="orientation">The orientation.</param>
+        /// <returns>
+        /// The <see cref="bool"/> indicating whether orientation should be handled.
+        /// </returns>
+        public static bool GetOrientation(FormattedImage image, CommandCollection commands, CommandParser parser, CultureInfo culture, out ushort orientation)
+        {
+            // Browsers now implement 'image-orientation: from-image' by default.
+            // https://developer.mozilla.org/en-US/docs/web/css/image-orientation
+            // This makes orientation handling confusing for users who expect images to be resized in accordance
+            // to what they observe rather than pure (and correct) methods.
+            //
+            // To accomodate this we parse the dimensions to use based upon decoded EXIF orientation values.
+            // We default to 'true' for EXIF orientation handling. By passing 'false' it can be turned off.
+            if (commands.Contains(Command) && !parser.ParseValue<bool>(commands.GetValueOrDefault(Command), culture))
+            {
+                orientation = ExifOrientationMode.Unknown;
+                return false;
+            }
+
+            return image.TryGetExifOrientation(out orientation) && orientation != ExifOrientationMode.TopLeft;
+        }
+
+        /// <summary>
+        /// Transforms the specified value depending on the specified <paramref name="orientation" />.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="orientation">The EXIF orientation.</param>
+        public static void Transform(ref ResizeOptions value, ushort orientation)
+        {
+            value.Size = Transform(value.Size, orientation);
+
+            if (value.CenterCoordinates.HasValue)
+            {
+                value.CenterCoordinates = Transform(value.CenterCoordinates.Value, orientation);
+            }
+
+            value.Position = Transform(value.Position, orientation);
+        }
+
+        /// <summary>
+        /// Transforms the specified value depending on the specified <paramref name="orientation" />.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="orientation">The EXIF orientation.</param>
+        /// <returns>
+        /// The transformed value.
+        /// </returns>
+        public static Size Transform(Size value, ushort orientation)
+            => orientation switch
+            {
+                ExifOrientationMode.LeftTop or
+                ExifOrientationMode.RightTop or
+                ExifOrientationMode.RightBottom or
+                ExifOrientationMode.LeftBottom => new Size(value.Height, value.Width),
+                _ => value
+            };
+
+        /// <summary>
+        /// Transforms the specified value depending on the specified <paramref name="orientation" />.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="orientation">The EXIF orientation.</param>
+        /// <returns>
+        /// The transformed value.
+        /// </returns>
+        public static PointF Transform(PointF value, ushort orientation)
+        {
+            AffineTransformBuilder builder = new();
+            Size sourceSize = new(1, 1);
+
+            // New XY is calculated based on flipping and rotating the input XY
+            switch (orientation)
+            {
+                case ExifOrientationMode.TopRight:
+                    builder.AppendTranslation(new PointF(sourceSize.Width - value.X, 0));
+                    break;
+                case ExifOrientationMode.BottomRight:
+                    builder.AppendRotationDegrees(180);
+                    builder.AppendTranslation(new PointF(0, -(sourceSize.Height - value.Y)));
+                    break;
+                case ExifOrientationMode.BottomLeft:
+                    builder.AppendRotationDegrees(180);
+                    builder.AppendTranslation(new PointF(sourceSize.Width - value.X, -(sourceSize.Height - value.Y)));
+                    break;
+                case ExifOrientationMode.LeftTop:
+                    builder.AppendRotationDegrees(90);
+                    builder.AppendTranslation(new PointF(sourceSize.Width - value.X, 0));
+                    break;
+                case ExifOrientationMode.RightTop:
+                    builder.AppendRotationDegrees(270);
+                    break;
+                case ExifOrientationMode.RightBottom:
+                    builder.AppendRotationDegrees(270);
+                    builder.AppendTranslation(new PointF(-(sourceSize.Width - value.X), -(sourceSize.Height - value.Y)));
+                    break;
+                case ExifOrientationMode.LeftBottom:
+                    builder.AppendRotationDegrees(90);
+                    builder.AppendTranslation(new PointF(-(sourceSize.Width - value.X), 0));
+                    break;
+                default:
+                    return value;
+            }
+
+            Matrix3x2 matrix = builder.BuildMatrix(sourceSize);
+
+            return Vector2.Transform(value, matrix);
+        }
+
+        /// <summary>
+        /// Transforms the specified value depending on the specified <paramref name="orientation" />.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="orientation">The EXIF orientation.</param>
+        /// <returns>
+        /// The transformed value.
+        /// </returns>
+        public static AnchorPositionMode Transform(AnchorPositionMode value, ushort orientation)
+             => value switch
+             {
+                 AnchorPositionMode.Center => value,
+                 AnchorPositionMode.Top => orientation switch
+                 {
+                     ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Bottom,
+                     ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Left,
+                     ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Right,
+                     _ => value,
+                 },
+                 AnchorPositionMode.Bottom => orientation switch
+                 {
+                     ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Top,
+                     ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Right,
+                     ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Left,
+                     _ => value,
+                 },
+                 AnchorPositionMode.Left => orientation switch
+                 {
+                     ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Right,
+                     ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
+                     ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
+                     _ => value,
+                 },
+                 AnchorPositionMode.Right => orientation switch
+                 {
+                     ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Left,
+                     ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Bottom,
+                     ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Top,
+                     _ => value,
+                 },
+                 AnchorPositionMode.TopLeft => orientation switch
+                 {
+                     ExifOrientationMode.TopRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopRight,
+                     ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomLeft,
+                     ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.BottomRight,
+                     _ => value,
+                 },
+                 AnchorPositionMode.TopRight => orientation switch
+                 {
+                     ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopLeft,
+                     ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
+                     ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
+                     _ => value,
+                 },
+                 AnchorPositionMode.BottomRight => orientation switch
+                 {
+                     ExifOrientationMode.TopRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomLeft,
+                     ExifOrientationMode.BottomLeft or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
+                     ExifOrientationMode.BottomRight or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
+                     _ => value,
+                 },
+                 AnchorPositionMode.BottomLeft => orientation switch
+                 {
+                     ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomRight,
+                     ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
+                     ExifOrientationMode.BottomRight or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
+                     _ => value,
+                 },
+                 _ => value,
+             };
+    }
+}

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -3,9 +3,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using System.Numerics;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 using SixLabors.ImageSharp.Web.Commands;
@@ -48,41 +46,29 @@ namespace SixLabors.ImageSharp.Web.Processors
         public const string Anchor = "ranchor";
 
         /// <summary>
-        /// The command constant for the resize orientation handling mode.
-        /// </summary>
-        public const string Orient = "orient";
-
-        /// <summary>
         /// The command constant for the resize compand mode.
         /// </summary>
         public const string Compand = "compand";
 
-        private static readonly IEnumerable<string> ResizeCommands
-            = new[]
-            {
-                Width,
-                Height,
-                Xy,
-                Mode,
-                Sampler,
-                Anchor,
-                Compand,
-                Orient
-            };
+        private static readonly IEnumerable<string> ResizeCommands = new[]
+        {
+            Width,
+            Height,
+            Xy,
+            Mode,
+            Sampler,
+            Anchor,
+            Compand,
+            OrientationHelper.Command
+        };
 
         /// <inheritdoc/>
         public IEnumerable<string> Commands { get; } = ResizeCommands;
 
         /// <inheritdoc/>
-        public FormattedImage Process(
-            FormattedImage image,
-            ILogger logger,
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
+        public FormattedImage Process(FormattedImage image, ILogger logger, CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
             ResizeOptions options = GetResizeOptions(image, commands, parser, culture);
-
             if (options != null)
             {
                 image.Image.Mutate(x => x.Resize(options));
@@ -101,21 +87,14 @@ namespace SixLabors.ImageSharp.Web.Processors
         /// The <see cref="CultureInfo"/> to use as the current parsing culture.
         /// </param>
         /// <returns>The <see cref="ResizeOptions"/>.</returns>
-        internal static ResizeOptions GetResizeOptions(
-            FormattedImage image,
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
+        internal static ResizeOptions GetResizeOptions(FormattedImage image, CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
             if (!commands.Contains(Width) && !commands.Contains(Height))
             {
                 return null;
             }
 
-            bool rotated = ShouldHandleExifRotation(image, commands, parser, culture, out ushort orientation);
-
-            Size size = ParseSize(rotated, commands, parser, culture);
-
+            Size size = ParseSize(commands, parser, culture);
             if (size.Width <= 0 && size.Height <= 0)
             {
                 return null;
@@ -123,196 +102,50 @@ namespace SixLabors.ImageSharp.Web.Processors
 
             ResizeOptions options = new()
             {
-                Size = size,
-                CenterCoordinates = GetCenter(image, orientation, commands, parser, culture),
-                Position = GetAnchor(orientation, commands, parser, culture),
                 Mode = GetMode(commands, parser, culture),
+                Position = GetAnchor(commands, parser, culture),
+                CenterCoordinates = GetCenter(commands, parser, culture),
+                Size = size,
+                Sampler = GetSampler(commands),
                 Compand = GetCompandMode(commands, parser, culture),
             };
 
-            // Defaults to Bicubic if not set.
-            options.Sampler = GetSampler(commands);
+            // Add support for EXIF orientation aware resizing
+            if (OrientationHelper.GetOrientation(image, commands, parser, culture, out ushort orientation))
+            {
+                OrientationHelper.Transform(ref options, orientation);
+            }
 
             return options;
         }
 
-        private static Size ParseSize(
-            bool rotated,
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
+        private static Size ParseSize(CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
-            // The command parser will reject negative numbers as it clamps values to ranges.
+            // The command parser will reject negative numbers as it clamps values to ranges
             int width = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Width), culture);
             int height = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Height), culture);
-            return rotated ? new Size(height, width) : new Size(width, height);
+
+            return new Size(width, height);
         }
 
-        private static PointF? GetCenter(
-            FormattedImage image,
-            ushort orientation,
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
+        private static PointF? GetCenter(CommandCollection commands, CommandParser parser, CultureInfo culture)
         {
             float[] coordinates = parser.ParseValue<float[]>(commands.GetValueOrDefault(Xy), culture);
-
             if (coordinates.Length != 2)
             {
                 return null;
             }
 
-            PointF center = new(coordinates[0], coordinates[1]);
-            if (orientation is >= ExifOrientationMode.Unknown and <= ExifOrientationMode.TopLeft)
-            {
-                return center;
-            }
-
-            AffineTransformBuilder builder = new();
-            Size size = image.Image.Size();
-
-            // New XY is calculated based on flipping and rotating the input XY.
-            // Operations are based upon AutoOrientProcessor implementation.
-            switch (orientation)
-            {
-                case ExifOrientationMode.TopRight:
-                    builder.AppendTranslation(new PointF(size.Width - center.X, 0));
-                    break;
-                case ExifOrientationMode.BottomRight:
-                    builder.AppendRotationDegrees(180);
-                    builder.AppendTranslation(new PointF(0, -(size.Height - center.Y)));
-                    break;
-                case ExifOrientationMode.BottomLeft:
-                    builder.AppendRotationDegrees(180);
-                    builder.AppendTranslation(new PointF(size.Width - center.X, -(size.Height - center.Y)));
-                    break;
-                case ExifOrientationMode.LeftTop:
-                    builder.AppendRotationDegrees(90);
-                    builder.AppendTranslation(new PointF(size.Width - center.X, 0));
-                    break;
-                case ExifOrientationMode.RightTop:
-                    builder.AppendRotationDegrees(270);
-                    break;
-                case ExifOrientationMode.RightBottom:
-                    builder.AppendRotationDegrees(270);
-                    builder.AppendTranslation(new PointF(-(size.Width - center.X), -(size.Height - center.Y)));
-                    break;
-                case ExifOrientationMode.LeftBottom:
-                    builder.AppendRotationDegrees(90);
-                    builder.AppendTranslation(new PointF(-(size.Width - center.X), 0));
-                    break;
-                default:
-                    return center;
-            }
-
-            Matrix3x2 matrix = builder.BuildMatrix(size);
-            return Vector2.Transform(center, matrix);
+            return new(coordinates[0], coordinates[1]);
         }
 
-        private static ResizeMode GetMode(
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
+        private static ResizeMode GetMode(CommandCollection commands, CommandParser parser, CultureInfo culture)
             => parser.ParseValue<ResizeMode>(commands.GetValueOrDefault(Mode), culture);
 
-        private static AnchorPositionMode GetAnchor(
-            ushort orientation,
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
-        {
-            AnchorPositionMode anchor = parser.ParseValue<AnchorPositionMode>(commands.GetValueOrDefault(Anchor), culture);
-            if (orientation is >= ExifOrientationMode.Unknown and <= ExifOrientationMode.TopLeft)
-            {
-                return anchor;
-            }
+        private static AnchorPositionMode GetAnchor(CommandCollection commands, CommandParser parser, CultureInfo culture)
+            => parser.ParseValue<AnchorPositionMode>(commands.GetValueOrDefault(Anchor), culture);
 
-            /*
-                New anchor position is determined by calculating the direction of the anchor relative to the source image.
-                In the following example, the TopRight anchor becomes BottomRight
-
-                            T                              L
-                +-----------------------+           +--------------+
-                |                      *|           |              |
-                |                       |           |              |
-              L |           TL          | R         |              |
-                |                       |           |              |
-                |                       |         B |      LB      | T
-                |                       |           |              |
-                +-----------------------+           |              |
-                            B                       |              |
-                                                    |              |
-                                                    |             *|
-                                                    +--------------+
-                                                            R
-          */
-            return anchor switch
-            {
-                AnchorPositionMode.Center => anchor,
-                AnchorPositionMode.Top => orientation switch
-                {
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Bottom,
-                    ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Left,
-                    ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Right,
-                    _ => anchor,
-                },
-                AnchorPositionMode.Bottom => orientation switch
-                {
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.BottomRight => AnchorPositionMode.Top,
-                    ExifOrientationMode.LeftTop or ExifOrientationMode.RightTop => AnchorPositionMode.Right,
-                    ExifOrientationMode.LeftBottom or ExifOrientationMode.RightBottom => AnchorPositionMode.Left,
-                    _ => anchor,
-                },
-                AnchorPositionMode.Left => orientation switch
-                {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Right,
-                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Top,
-                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Bottom,
-                    _ => anchor,
-                },
-                AnchorPositionMode.Right => orientation switch
-                {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.BottomRight => AnchorPositionMode.Left,
-                    ExifOrientationMode.LeftTop or ExifOrientationMode.LeftBottom => AnchorPositionMode.Bottom,
-                    ExifOrientationMode.RightTop or ExifOrientationMode.RightBottom => AnchorPositionMode.Top,
-                    _ => anchor,
-                },
-                AnchorPositionMode.TopLeft => orientation switch
-                {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopRight,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomLeft,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightBottom => AnchorPositionMode.BottomRight,
-                    _ => anchor,
-                },
-                AnchorPositionMode.TopRight => orientation switch
-                {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.TopLeft,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomRight,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftTop => AnchorPositionMode.BottomLeft,
-                    _ => anchor,
-                },
-                AnchorPositionMode.BottomRight => orientation switch
-                {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.LeftBottom => AnchorPositionMode.BottomLeft,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.RightTop => AnchorPositionMode.TopRight,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.RightBottom => AnchorPositionMode.TopLeft,
-                    _ => anchor,
-                },
-                AnchorPositionMode.BottomLeft => orientation switch
-                {
-                    ExifOrientationMode.TopRight or ExifOrientationMode.RightTop => AnchorPositionMode.BottomRight,
-                    ExifOrientationMode.BottomLeft or ExifOrientationMode.LeftBottom => AnchorPositionMode.TopLeft,
-                    ExifOrientationMode.BottomRight or ExifOrientationMode.LeftTop => AnchorPositionMode.TopRight,
-                    _ => anchor,
-                },
-                _ => anchor,
-            };
-        }
-
-        private static bool GetCompandMode(
-            CommandCollection commands,
-            CommandParser parser,
-            CultureInfo culture)
+        private static bool GetCompandMode(CommandCollection commands, CommandParser parser, CultureInfo culture)
             => parser.ParseValue<bool>(commands.GetValueOrDefault(Compand), culture);
 
         private static IResampler GetSampler(CommandCollection commands)
@@ -343,25 +176,6 @@ namespace SixLabors.ImageSharp.Web.Processors
             }
 
             return KnownResamplers.Bicubic;
-        }
-
-        private static bool ShouldHandleExifRotation(FormattedImage image, CommandCollection commands, CommandParser parser, CultureInfo culture, out ushort orientation)
-        {
-            // Browsers now implement 'image-orientation: from-image' by default.
-            // https://developer.mozilla.org/en-US/docs/web/css/image-orientation
-            // This makes orientation handling confusing for users who expect images to be resized in accordance
-            // to what they observe rather than pure (and correct) methods.
-            //
-            // To accomodate this we parse the dimensions to use based upon decoded EXIF orientation values, switching
-            // the width/height parameters when images are rotated (not flipped).
-            // We default to 'true' for EXIF orientation handling. By passing 'false' it can be turned off.
-            if (commands.Contains(Orient) && !parser.ParseValue<bool>(commands.GetValueOrDefault(Orient), culture))
-            {
-                orientation = ExifOrientationMode.Unknown;
-                return false;
-            }
-
-            return image.IsExifRotated(out orientation);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR moves the orientation related parsing/transforms into a re-usable `OrientationHelper` and also fixes the transforms done on the center coordinates.