### PR TITLE
Add FileProviderImageProvider and WebRootImageProvider 

### DIFF
--- a/src/ImageSharp.Web/Providers/FileProviderImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/FileProviderImageProvider.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.FileProviders;
+using SixLabors.ImageSharp.Web.Resolvers;
+
+namespace SixLabors.ImageSharp.Web.Providers
+{
+    /// <summary>
+    /// Returns images from an <see cref="IFileProvider"/> abstraction.
+    /// </summary>
+    public class FileProviderImageProvider : IImageProvider
+    {
+        /// <summary>
+        /// The file provider abstraction.
+        /// </summary>
+        private readonly IFileProvider fileProvider;
+
+        /// <summary>
+        /// Contains various format helper methods based on the current configuration.
+        /// </summary>
+        private readonly FormatUtilities formatUtilities;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileProviderImageProvider"/> class.
+        /// </summary>
+        /// <param name="fileProvider">The file provider.</param>
+        /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
+        public FileProviderImageProvider(IFileProvider fileProvider, FormatUtilities formatUtilities)
+        {
+            this.fileProvider = fileProvider ?? throw new ArgumentNullException(nameof(fileProvider));
+            this.formatUtilities = formatUtilities ?? throw new ArgumentNullException(nameof(formatUtilities));
+        }
+
+        /// <inheritdoc/>
+        public ProcessingBehavior ProcessingBehavior { get; protected set; } = ProcessingBehavior.CommandOnly;
+
+        /// <inheritdoc/>
+        public Func<HttpContext, bool> Match { get; set; } = _ => true;
+
+        /// <inheritdoc/>
+        public bool IsValidRequest(HttpContext context)
+            => this.formatUtilities.TryGetExtensionFromUri(context.Request.GetDisplayUrl(), out _);
+
+        /// <inheritdoc/>
+        public Task<IImageResolver> GetAsync(HttpContext context)
+        {
+            IFileInfo fileInfo = this.fileProvider.GetFileInfo(context.Request.Path);
+            if (!fileInfo.Exists)
+            {
+                return Task.FromResult<IImageResolver>(null);
+            }
+
+            return Task.FromResult<IImageResolver>(new FileProviderImageResolver(fileInfo));
+        }
+    }
+}

--- a/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.AspNetCore.Hosting;
+
+namespace SixLabors.ImageSharp.Web.Providers
+{
+    /// <summary>
+    /// Returns images from the web root file provider.
+    /// </summary>
+    public sealed class WebRootImageProvider : FileProviderImageProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebRootImageProvider"/> class.
+        /// </summary>
+        /// <param name="environment">The web hosting environment.</param>
+        /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
+        public WebRootImageProvider(
+#if NETCOREAPP2_1
+            IHostingEnvironment environment,
+#else
+            IWebHostEnvironment environment,
+#endif
+            FormatUtilities formatUtilities)
+            : base(environment.WebRootFileProvider, formatUtilities)
+        {
+        }
+    }
+}

--- a/src/ImageSharp.Web/Resolvers/FileProviderImageResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/FileProviderImageResolver.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+
+namespace SixLabors.ImageSharp.Web.Resolvers
+{
+    /// <summary>
+    /// Provides means to manage image buffers from an <see cref="IFileInfo"/> instance.
+    /// </summary>
+    public sealed class FileProviderImageResolver : IImageResolver
+    {
+        private readonly IFileInfo fileInfo;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileProviderImageResolver"/> class.
+        /// </summary>
+        /// <param name="fileInfo">The file info.</param>
+        public FileProviderImageResolver(IFileInfo fileInfo) => this.fileInfo = fileInfo;
+
+        /// <inheritdoc/>
+        public Task<ImageMetadata> GetMetaDataAsync() => Task.FromResult(new ImageMetadata(this.fileInfo.LastModified.UtcDateTime, this.fileInfo.Length));
+
+        /// <inheritdoc/>
+        public Task<Stream> OpenReadAsync() => Task.FromResult(this.fileInfo.CreateReadStream());
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This adds a `FileProviderImageProvider` and `WebRootImageProvider`, following the pattern mentioned in https://github.com/umbraco/Umbraco-CMS/pull/12185#discussion_r838138281. This is basically a simplified version of PR https://github.com/SixLabors/ImageSharp.Web/pull/207, but these `IImageProvider`s are now included as additional, non-default implementations.

This would allow users to easily switch from the default `PhysicalFileSystemProvider` to the `WebRootImageProvider` by using:
```c#
services.AddImageSharp()
    .RemoveProvider<PhysicalFileSystemProvider>() // or .ClearProviders()
    .AddProvider<WebRootImageProvider>();
```