### PR TITLE
ImageMetadata and ImageCacheMetadata initialization improvements

### DIFF
--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -70,8 +70,7 @@ namespace SixLabors.ImageSharp.Web.Providers
                 var fileInfo = new FileInfo(fullPath);
                 if (fileInfo.Exists)
                 {
-                    var metadata = new ImageMetadata(fileInfo.LastWriteTimeUtc, fileInfo.Length);
-                    return Task.FromResult<IImageResolver>(new PhysicalFileSystemResolver(fileInfo, metadata));
+                    return Task.FromResult<IImageResolver>(new PhysicalFileSystemResolver(fileInfo));
                 }
             }
 

--- a/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
+++ b/src/ImageSharp.Web/Resolvers/PhysicalFileSystemResolver.cs
@@ -12,21 +12,15 @@ namespace SixLabors.ImageSharp.Web.Resolvers
     public class PhysicalFileSystemResolver : IImageResolver
     {
         private readonly FileInfo fileInfo;
-        private readonly ImageMetadata metadata;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PhysicalFileSystemResolver"/> class.
         /// </summary>
         /// <param name="fileInfo">The input file info.</param>
-        /// <param name="metadata">The image metadata associated with this file.</param>
-        public PhysicalFileSystemResolver(FileInfo fileInfo, in ImageMetadata metadata)
-        {
-            this.fileInfo = fileInfo;
-            this.metadata = metadata;
-        }
+        public PhysicalFileSystemResolver(FileInfo fileInfo) => this.fileInfo = fileInfo;
 
         /// <inheritdoc/>
-        public Task<ImageMetadata> GetMetaDataAsync() => Task.FromResult(this.metadata);
+        public Task<ImageMetadata> GetMetaDataAsync() => Task.FromResult(new ImageMetadata(this.fileInfo.LastWriteTimeUtc, this.fileInfo.Length));
 
         /// <inheritdoc/>
         public Task<Stream> OpenReadAsync()


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I noticed the `PhysicalFileSystemProvider` always initialized an `ImageMetadata` that requires fetching the `LastWriteTimeUtc` and `Length`, potentially requiring disk I/O (see [reference source](https://github.com/microsoft/referencesource/blob/master/mscorlib/system/io/filesysteminfo.cs#L252-L281)).

I also noticed `PhysicalFileSystemCacheResolver` assumed the `ImageCacheMetadata` was already initialized by `GetMetaDataAsync()`, meaning `OpenReadAsync()` would only work when `GetMetaDataAsync()` was called first. In addition, calling `GetMetaDataAsync()` multiple times would re-initialize the metadata.