### PR TITLE
Add InsertProvider extensions and tests

### DIFF
--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -165,7 +165,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         public static IImageSharpBuilder InsertProvider<TProvider>(this IImageSharpBuilder builder, int index)
             where TProvider : class, IImageProvider
         {
-            var descriptors = builder.Services.Where(x => x.ServiceType == typeof(IImageProvider) && x.Lifetime == ServiceLifetime.Singleton).ToList();
+            var descriptors = builder.Services.Where(x => x.ServiceType == typeof(IImageProvider)).ToList();
             builder.ClearProviders();
 
             descriptors.Insert(index, ServiceDescriptor.Singleton<IImageProvider, TProvider>());
@@ -185,7 +185,7 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         public static IImageSharpBuilder InsertProvider<TProvider>(this IImageSharpBuilder builder, int index, Func<IServiceProvider, TProvider> implementationFactory)
             where TProvider : class, IImageProvider
         {
-            var descriptors = builder.Services.Where(x => x.ServiceType == typeof(IImageProvider) && x.Lifetime == ServiceLifetime.Singleton).ToList();
+            var descriptors = builder.Services.Where(x => x.ServiceType == typeof(IImageProvider)).ToList();
             builder.ClearProviders();
 
             descriptors.Insert(index, ServiceDescriptor.Singleton<IImageProvider>(implementationFactory));
@@ -205,7 +205,6 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         {
             ServiceDescriptor descriptor = builder.Services.FirstOrDefault(x =>
                 x.ServiceType == typeof(IImageProvider)
-                && x.Lifetime == ServiceLifetime.Singleton
                 && (x.ImplementationType == typeof(TProvider)
                 || (x.ImplementationFactory?.GetMethodInfo().ReturnType == typeof(TProvider))));
 

--- a/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ImageSharpBuilderExtensions.cs
@@ -156,6 +156,45 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
         }
 
         /// <summary>
+        /// Inserts the given <see cref="IImageProvider"/> at the give index into to the provider collection within the service collection.
+        /// </summary>
+        /// <typeparam name="TProvider">The type of class implementing <see cref="IImageProvider"/>to add.</typeparam>
+        /// <param name="builder">The core builder.</param>
+        /// <param name="index">The zero-based index at which the provider should be inserted.</param>
+        /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
+        public static IImageSharpBuilder InsertProvider<TProvider>(this IImageSharpBuilder builder, int index)
+            where TProvider : class, IImageProvider
+        {
+            var descriptors = builder.Services.Where(x => x.ServiceType == typeof(IImageProvider) && x.Lifetime == ServiceLifetime.Singleton).ToList();
+            builder.ClearProviders();
+
+            descriptors.Insert(index, ServiceDescriptor.Singleton<IImageProvider, TProvider>());
+
+            builder.Services.TryAddEnumerable(descriptors);
+            return builder;
+        }
+
+        /// <summary>
+        /// Inserts the given <see cref="IImageProvider"/>  at the give index into the provider collection within the service collection.
+        /// </summary>
+        /// <typeparam name="TProvider">The type of class implementing <see cref="IImageProvider"/>to add.</typeparam>
+        /// <param name="builder">The core builder.</param>
+        /// <param name="index">The zero-based index at which the provider should be inserted.</param>
+        /// <param name="implementationFactory">The factory method for returning a <see cref="IImageProvider"/>.</param>
+        /// <returns>The <see cref="IImageSharpBuilder"/>.</returns>
+        public static IImageSharpBuilder InsertProvider<TProvider>(this IImageSharpBuilder builder, int index, Func<IServiceProvider, TProvider> implementationFactory)
+            where TProvider : class, IImageProvider
+        {
+            var descriptors = builder.Services.Where(x => x.ServiceType == typeof(IImageProvider) && x.Lifetime == ServiceLifetime.Singleton).ToList();
+            builder.ClearProviders();
+
+            descriptors.Insert(index, ServiceDescriptor.Singleton<IImageProvider>(implementationFactory));
+
+            builder.Services.TryAddEnumerable(descriptors);
+            return builder;
+        }
+
+        /// <summary>
         /// Removes the given <see cref="IImageProvider"/> from the provider collection within the service collection.
         /// </summary>
         /// <typeparam name="TProvider">The type of class implementing <see cref="IImageProvider"/>to add.</typeparam>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds the ability to insert an `IImageProvider` or factory into the provider collection. This reduces boilerplate code when adding multiple providers.

<!-- Thanks for contributing to ImageSharp! -->
