### PR TITLE
Remove HMAC caching by token

### DIFF
--- a/tests/ImageSharp.Web.Tests/Helpers/HMACUtilitiesTests.cs
+++ b/tests/ImageSharp.Web.Tests/Helpers/HMACUtilitiesTests.cs
@@ -10,39 +10,39 @@ namespace SixLabors.ImageSharp.Web.Tests.Helpers
         private static readonly byte[] HMACSecretKey = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 };
 
         [Theory]
-        [InlineData("The quick brown fox jumped.")]
-        [InlineData("Over the lazy dog.")]
-        public void CanGenerate256BitHMAC(string value)
+        [InlineData("The quick brown fox jumped.", "8ac58e6e983b9cdea7771a2f68b7430c8923ce43f690e23a51192f427fd7ece9")]
+        [InlineData("Over the lazy dog.", "2ea9f37afac5ae93e27d835cc6061ad84b31064ae29f451c9136e88ad5686a1e")]
+        public void CanGenerate256BitHMAC(string value, string expected)
         {
-            string expected = HMACUtilities.ComputeHMACSHA256(value, HMACSecretKey);
             string actual = HMACUtilities.ComputeHMACSHA256(value, HMACSecretKey);
 
+            Assert.NotNull(actual);
+            Assert.Equal(64, actual.Length);
             Assert.Equal(expected, actual);
-            Assert.Equal(64, expected.Length);
         }
 
         [Theory]
-        [InlineData("The quick brown fox jumped.")]
-        [InlineData("Over the lazy dog.")]
-        public void CanGenerate384BitHMAC(string value)
+        [InlineData("The quick brown fox jumped.", "1e955e8f1b00f53b39c318d14068f2efe7c409990201f1c93f641b0d631300d32bb60a818344aa3e644f98e15ae667ad")]
+        [InlineData("Over the lazy dog.", "5430f82f9b105a35a205f872b8d30041a37dfe1140011ef33d61bd87c932e7d2662136d2f8f1b550eaec99d5b1fd8351")]
+        public void CanGenerate384BitHMAC(string value, string expected)
         {
-            string expected = HMACUtilities.ComputeHMACSHA384(value, HMACSecretKey);
             string actual = HMACUtilities.ComputeHMACSHA384(value, HMACSecretKey);
 
+            Assert.NotNull(actual);
+            Assert.Equal(96, actual.Length);
             Assert.Equal(expected, actual);
-            Assert.Equal(96, expected.Length);
         }
 
         [Theory]
-        [InlineData("The quick brown fox jumped.")]
-        [InlineData("Over the lazy dog.")]
-        public void CanGenerate512BitHMAC(string value)
+        [InlineData("The quick brown fox jumped.", "1efec919563bfb3f0e0334f91133c9d55170f5ac55834f0bf7c8e367c9adfd8127815fef19e742ac021ea7da728a85dfc3ddfc894402706b27247126fbefd6e7")]
+        [InlineData("Over the lazy dog.", "faaa0fbca75e0efce73126770735e1a7c43a1971ea6d7105523ff29e093e7422537a6dac2799e6bb9bec7004d04f6e7308aeb4c4a27ab9bd964d26127ae8f7c8")]
+        public void CanGenerate512BitHMAC(string value, string expected)
         {
-            string expected = HMACUtilities.ComputeHMACSHA512(value, HMACSecretKey);
             string actual = HMACUtilities.ComputeHMACSHA512(value, HMACSecretKey);
 
+            Assert.NotNull(actual);
+            Assert.Equal(128, actual.Length);
             Assert.Equal(expected, actual);
-            Assert.Equal(128, expected.Length);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
As mentioned in https://github.com/SixLabors/ImageSharp.Web/pull/250/files#r857755086, caching generated HMACs based on the token completely bypasses the validation, because the cache key doesn't change when the commands are changed and therefore returns the same valid HMAC when the token is used with different commands.

I've thought about creating a better key for the HMAC cache, but that would also require additional processing and you might get similar issues when that cache key doesn't use the same information as `OnComputeHMACAsync` does (e.g. the HMAC cache key uses a relative URL, but the HMAC is computed using an absolute URL).

The overhead of generating HMACs is also relatively low and attackers could otherwise just change the URL slightly to bypass the cached HMACs anyway. This is why I think completely removing the HMAC cache seems like the most reasonable fix.

-------------------

You can quickly test this by using the following code and appending `&hmac=` with the logged value:
```c#
using System.Security.Cryptography;
using Microsoft.AspNetCore.Http.Extensions;

services.AddImageSharp(options =>
{
    // Randomly generate a HMAC secret key
    byte[] secret = new byte[64];
    RandomNumberGenerator.Create().GetBytes(secret);
    options.HMACSecretKey = secret;

    // Log computed HMAC to console for testing
    var onComputeHMACAsync = options.OnComputeHMACAsync;
    options.OnComputeHMACAsync = async (context, secret) =>
    {
        var hmac = await onComputeHMACAsync(context, secret);

        Console.WriteLine($"Computed HMAC for {context.Context.Request.GetDisplayUrl()}: {hmac}");

        return hmac;
    };
});