### PR TITLE
Fix retry loop on exception

### DIFF
--- a/src/ImageSharp.Web/Commands/CommandCollection.cs
+++ b/src/ImageSharp.Web/Commands/CommandCollection.cs
@@ -29,16 +29,7 @@ namespace SixLabors.ImageSharp.Web.Commands
         /// <summary>
         /// Gets an <see cref="IEnumerable{String}"/> representing the keys of the collection.
         /// </summary>
-        public IEnumerable<string> Keys
-        {
-            get
-            {
-                foreach (KeyValuePair<string, string> item in this)
-                {
-                    yield return this.GetKeyForItem(item);
-                }
-            }
-        }
+        public IEnumerable<string> Keys => this.Dictionary.Keys; // TODO Change return type to ICollection<string> in next major release
 
         /// <summary>
         /// Gets or sets the value associated with the specified key.

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -211,18 +211,13 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
             if (commands.Count > 0)
             {
-                // Strip out any unknown commands, if needed.
-                int index = 0;
+                // Strip out any unknown commands
                 foreach (string command in commands.Keys)
                 {
                     if (!this.knownCommands.Contains(command))
                     {
-                        // Need to actually remove, allocates new list to allow modifications
-                        this.StripUnknownCommands(commands, index);
-                        break;
+                        commands.Remove(command);
                     }
-
-                    index++;
                 }
             }
 
@@ -304,19 +299,6 @@ namespace SixLabors.ImageSharp.Web.Middleware
             // We don't log the error to avoid attempts at log poisoning.
             httpContext.Response.Clear();
             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-        }
-
-        private void StripUnknownCommands(CommandCollection commands, int startAtIndex)
-        {
-            var keys = new List<string>(commands.Keys);
-            for (int index = startAtIndex; index < keys.Count; index++)
-            {
-                string command = keys[index];
-                if (!this.knownCommands.Contains(command))
-                {
-                    commands.Remove(command);
-                }
-            }
         }
 
         private async Task ProcessRequestAsync(


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
PR https://github.com/SixLabors/ImageSharp.Web/pull/240 added a retry in case reading the cached file caused an exception (e.g. when the file got deleted while still in the internal LRU cache). I tested whether that PR fixed the issue, but didn't spot the retry loop: if reading the cached file keeps throwing exceptions, it will go into an infinite loop.

You can test this by getting an exclusive lock on a cached file and requesting that respective URL. You can do this with PowerShell by executing `$fileStream = [System.IO.File]::Open("1f85.jpg", "Open", "Write")` (where `1f85.jpg` is the cached file name). The request will only finish after executing `$fileStream.Dispose();` to release the exclusive lock...

I've also removed allocating a new list to strip unknown commands (AFAIK `Dictionary.Keys` uses an existing collection to return the keys) and ensured the middleware first tries to get a valid provider before parsing commands/capturing the HMAC token, removing additional allocations (for invalid requests).