### PR TITLE
Re-add AutoOrientWebProcessor

### DIFF
--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -57,7 +57,8 @@ namespace SixLabors.ImageSharp.Web.Sample
                 .AddProcessor<ResizeWebProcessor>()
                 .AddProcessor<FormatWebProcessor>()
                 .AddProcessor<BackgroundColorWebProcessor>()
-                .AddProcessor<QualityWebProcessor>();
+                .AddProcessor<QualityWebProcessor>()
+                .AddProcessor<AutoOrientWebProcessor>();
 
             // Add the default service and options.
             //

--- a/samples/ImageSharp.Web.Sample/Startup.cs
+++ b/samples/ImageSharp.Web.Sample/Startup.cs
@@ -35,7 +35,7 @@ namespace SixLabors.ImageSharp.Web.Sample
         /// <summary>
         /// This method gets called by the runtime. Use this method to add services to the container.
         /// </summary>
-        /// <param name="services">The collection of service desscriptors.</param>
+        /// <param name="services">The collection of service descriptors.</param>
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddImageSharp()

--- a/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ImageSharp.Web/DependencyInjection/ServiceCollectionExtensions.cs
@@ -71,7 +71,8 @@ namespace SixLabors.ImageSharp.Web.DependencyInjection
             builder.AddProcessor<ResizeWebProcessor>()
                    .AddProcessor<FormatWebProcessor>()
                    .AddProcessor<BackgroundColorWebProcessor>()
-                   .AddProcessor<QualityWebProcessor>();
+                   .AddProcessor<QualityWebProcessor>()
+                   .AddProcessor<AutoOrientWebProcessor>();
 
             builder.AddConverter<IntegralNumberConverter<sbyte>>();
             builder.AddConverter<IntegralNumberConverter<byte>>();

--- a/src/ImageSharp.Web/Processors/AutoOrientWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/AutoOrientWebProcessor.cs
@@ -16,7 +16,7 @@ namespace SixLabors.ImageSharp.Web.Processors
     public class AutoOrientWebProcessor : IImageWebProcessor
     {
         /// <summary>
-        /// The command for changing the orientation.
+        /// The command for changing the orientation according to the EXIF information.
         /// </summary>
         public const string AutoOrient = "autoorient";
 
@@ -44,5 +44,8 @@ namespace SixLabors.ImageSharp.Web.Processors
 
             return image;
         }
+
+        /// <inheritdoc/>
+        public bool RequiresTrueColorPixelFormat(CommandCollection commands, CommandParser parser, CultureInfo culture) => false;
     }
 }

--- a/src/ImageSharp.Web/Processors/AutoOrientWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/AutoOrientWebProcessor.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Web.Commands;
+
+namespace SixLabors.ImageSharp.Web.Processors
+{
+    /// <summary>
+    /// Allows the auto-orientation to ensure that EXIF defined orientation is
+    /// reflected in the final image.
+    /// </summary>
+    public class AutoOrientWebProcessor : IImageWebProcessor
+    {
+        /// <summary>
+        /// The command for changing the orientation.
+        /// </summary>
+        public const string AutoOrient = "autoorient";
+
+        /// <summary>
+        /// The reusable collection of commands.
+        /// </summary>
+        private static readonly IEnumerable<string> AutoOrientCommands
+            = new[] { AutoOrient };
+
+        /// <inheritdoc/>
+        public IEnumerable<string> Commands { get; } = AutoOrientCommands;
+
+        /// <inheritdoc/>
+        public FormattedImage Process(
+            FormattedImage image,
+            ILogger logger,
+            CommandCollection commands,
+            CommandParser parser,
+            CultureInfo culture)
+        {
+            if (parser.ParseValue<bool>(commands.GetValueOrDefault(AutoOrient), culture))
+            {
+                image.Image.Mutate(x => x.AutoOrient());
+            }
+
+            return image;
+        }
+    }
+}

--- a/src/ImageSharp.Web/Processors/WebProcessingExtensions.cs
+++ b/src/ImageSharp.Web/Processors/WebProcessingExtensions.cs
@@ -48,7 +48,7 @@ namespace SixLabors.ImageSharp.Web.Processors
         /// <param name="processors">The collection of available processors.</param>
         /// <param name="commands">The parsed collection of processing commands.</param>
         /// <returns>
-        /// The sorted proccessors that supports any of the specified commands.
+        /// The sorted processors that supports any of the specified commands.
         /// </returns>
         public static IReadOnlyList<(int Index, IImageWebProcessor Processor)> OrderBySupportedCommands(this IEnumerable<IImageWebProcessor> processors, CommandCollection commands)
         {

--- a/tests/ImageSharp.Web.Tests/Processors/AutoOrientWebProcessorTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processors/AutoOrientWebProcessorTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Globalization;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Web.Commands;
+using SixLabors.ImageSharp.Web.Commands.Converters;
+using SixLabors.ImageSharp.Web.Processors;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Web.Tests.Processors
+{
+    public class AutoOrientWebProcessorTests
+    {
+        [Fact]
+        public void AutoOrientWebProcessor_UpdatesOrientation()
+        {
+            CommandParser parser = new(new[] { new SimpleCommandConverter<bool>() });
+            CultureInfo culture = CultureInfo.InvariantCulture;
+
+            CommandCollection commands = new()
+            {
+                { new(AutoOrientWebProcessor.AutoOrient, bool.TrueString) }
+            };
+
+            const ushort tl = 1;
+            const ushort br = 3;
+            using var image = new Image<Rgba32>(1, 1);
+            image.Metadata.ExifProfile = new();
+            image.Metadata.ExifProfile.SetValue(ExifTag.Orientation, br);
+
+            IExifValue<ushort> orientation = image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
+            Assert.Equal(br, orientation.Value);
+
+            using var formatted = new FormattedImage(image, PngFormat.Instance);
+            new AutoOrientWebProcessor().Process(formatted, null, commands, parser, culture);
+
+            orientation = image.Metadata.ExifProfile.GetValue(ExifTag.Orientation);
+            Assert.Equal(tl, orientation.Value);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

As discussed in #259: This PR re-adds `AutoOrientWebProcessor`