### PR TITLE
Added AuthenticationRegion to AmazonS3Client Endpoint based clients

### DIFF
--- a/src/ImageSharp.Web.Providers.AWS/AmazonS3ClientFactory.cs
+++ b/src/ImageSharp.Web.Providers.AWS/AmazonS3ClientFactory.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Web
             {
                 // AccessKey can be empty.
                 // AccessSecret can be empty.
-                AmazonS3Config config = new() { ServiceURL = options.Endpoint, ForcePathStyle = true };
+                AmazonS3Config config = new() { ServiceURL = options.Endpoint, ForcePathStyle = true, AuthenticationRegion = options.Region };
                 return new AmazonS3Client(options.AccessKey, options.AccessSecret, config);
             }
             else if (!string.IsNullOrWhiteSpace(options.AccessKey))


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Simply adding the optional `AuthenticationRegion` property to the `AmazonS3Config`.

https://github.com/SixLabors/ImageSharp.Web/issues/262

<!-- Thanks for contributing to ImageSharp! -->
