### PR TITLE
Use full URl as HMAC cache key

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -246,7 +246,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
 
             ImageCommandContext imageCommandContext = new(httpContext, commands, this.commandParser, this.parserCulture);
 
-            // At this point we know that this is an image request so should attempt to compute a validating HMAC..
+            // At this point we know that this is an image request so should attempt to compute a validating HMAC.
             string hmac = null;
             if (checkHMAC && token != null)
             {
@@ -256,7 +256,8 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 // the token will not match our validating HMAC, however, this would be indicative of an attack and should be treated as such.
                 //
                 // As a rule all image requests should contain valid commands only.
-                hmac = await HMACTokenLru.GetOrAddAsync(token, _ => this.options.OnComputeHMACAsync(imageCommandContext, secret));
+                // Key generation uses string.Create under the hood with very low allocation so should be good enough as a cache key.
+                hmac = await HMACTokenLru.GetOrAddAsync(httpContext.Request.GetEncodedUrl(), _ => this.options.OnComputeHMACAsync(imageCommandContext, secret));
             }
 
             await this.options.OnParseCommandsAsync.Invoke(imageCommandContext);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
As previously [identified](https://github.com/SixLabors/ImageSharp.Web/pull/250/files#r857755086) using only the token as a cache key opens the potential for abuse of the caching mechanism. PR #256 was opened to remove that cache. 

I would consider removing the cache with current target frameworks to be too expensive given the large overhead of  HMAC generation so have replaced that PR with an implementation that uses the full encoded URL as the key. 

The cache key generation method causes low allocations due to the underlying usage of [`string.Create`](https://github.com/dotnet/aspnetcore/issues/28906) so I would consider it acceptable for now. For .NET 6 we can likely remove the cache in it's entirety due to the much improved reusable hashing methods available to that framework.

<!-- Thanks for contributing to ImageSharp! -->
