### PR TITLE
Enumerate unordered keys during removal.

### DIFF
--- a/src/ImageSharp.Web/Commands/CommandCollection.cs
+++ b/src/ImageSharp.Web/Commands/CommandCollection.cs
@@ -41,6 +41,11 @@ namespace SixLabors.ImageSharp.Web.Commands
         }
 
         /// <summary>
+        /// Gets an <see cref="ICollection{String}"/> representing the keys of the collection in an undefined manner.
+        /// </summary>
+        internal ICollection<string> UnorderedKeys => this.Dictionary.Keys;
+
+        /// <summary>
         /// Gets or sets the value associated with the specified key.
         /// </summary>
         /// <param name="key">The key of the value to get or set.</param>

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -212,17 +212,12 @@ namespace SixLabors.ImageSharp.Web.Middleware
             if (commands.Count > 0)
             {
                 // Strip out any unknown commands, if needed.
-                int index = 0;
-                foreach (string command in commands.Keys)
+                foreach (string command in commands.UnorderedKeys)
                 {
                     if (!this.knownCommands.Contains(command))
                     {
-                        // Need to actually remove, allocates new list to allow modifications
-                        this.StripUnknownCommands(commands, index);
-                        break;
+                        commands.Remove(command);
                     }
-
-                    index++;
                 }
             }
 
@@ -305,19 +300,6 @@ namespace SixLabors.ImageSharp.Web.Middleware
             // We don't log the error to avoid attempts at log poisoning.
             httpContext.Response.Clear();
             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-        }
-
-        private void StripUnknownCommands(CommandCollection commands, int startAtIndex)
-        {
-            var keys = new List<string>(commands.Keys);
-            for (int index = startAtIndex; index < keys.Count; index++)
-            {
-                string command = keys[index];
-                if (!this.knownCommands.Contains(command))
-                {
-                    commands.Remove(command);
-                }
-            }
         }
 
         private async Task ProcessRequestAsync(

--- a/tests/ImageSharp.Web.Benchmarks/Commands/CommandCollectionBenchmarks.cs
+++ b/tests/ImageSharp.Web.Benchmarks/Commands/CommandCollectionBenchmarks.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using SixLabors.ImageSharp.Web.Commands;
+
+namespace SixLabors.ImageSharp.Web.Benchmarks.Commands
+{
+    [Config(typeof(MemoryConfig))]
+    public class CommandCollectionBenchmarks
+    {
+        private static readonly CommandCollection Commands = new()
+        {
+            { "width", "400" },
+            { "height", "400" }
+        };
+
+        private static readonly Consumer Consumer = new();
+
+        [Benchmark(Baseline = true, Description = nameof(CommandCollection.Keys))]
+        public void ConsumeKeys() => Commands.Keys.Consume(Consumer);
+
+        [Benchmark(Description = "KeysList")]
+        public void ConsumeKeysList() => new List<string>(Commands.Keys).Consume(Consumer);
+
+        [Benchmark(Description = nameof(CommandCollection.UnorderedKeys))]
+        public void ConsumeAllKeys() => Commands.UnorderedKeys.Consume(Consumer);
+
+        /*
+        BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+        11th Gen Intel Core i7-11370H 3.30GHz, 1 CPU, 8 logical and 4 physical cores
+        .NET SDK=6.0.300
+          [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
+          DefaultJob : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
+
+
+        |        Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
+        |-------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
+        |          Keys |  68.70 ns | 0.738 ns | 0.690 ns |  1.00 |    0.00 | 0.0153 |      96 B |
+        |      KeysList | 133.10 ns | 0.728 ns | 0.645 ns |  1.94 |    0.03 | 0.0355 |     224 B |
+        | UnorderedKeys |  32.70 ns | 0.174 ns | 0.154 ns |  0.48 |    0.01 | 0.0063 |      40 B |
+        */
+    }
+}

--- a/tests/ImageSharp.Web.Benchmarks/ImageSharp.Web.Benchmarks.csproj
+++ b/tests/ImageSharp.Web.Benchmarks/ImageSharp.Web.Benchmarks.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet"/>
+    <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Http"/>
+    <PackageReference Include="Microsoft.AspNetCore.Http" />
   </ItemGroup>
 
 </Project>

--- a/tests/ImageSharp.Web.Tests/Commands/CommandCollectionTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/CommandCollectionTests.cs
@@ -178,6 +178,24 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
         }
 
         [Fact]
+        public void KeysAndUnorderedKeysContainSameValues()
+        {
+            string[] keys = new[] { "a", "b", "c", "d" };
+
+            CommandCollection collection = new();
+            foreach (string key in keys)
+            {
+                collection.Insert(0, new(key, null));
+            }
+
+            foreach (string key in keys)
+            {
+                Assert.Contains(key, collection.Keys);
+                Assert.Contains(key, collection.UnorderedKeys);
+            }
+        }
+
+        [Fact]
         public void GetByInvalidKeyThrowsCorrectly()
             => Assert.Throws<KeyNotFoundException>(() =>
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
All credit goes to @ronaldbarendse for this as it was his idea and I've basically copied his implementation. 

Enumerating the underlying unordered key collection removes the overhead of allocating a list for each command collection during a request. Benchmarks show a 4x perf improvement plus 5x reduction in memory.

<!-- Thanks for contributing to ImageSharp! -->
