### PR TITLE
Optimize Invalid command removal.

### DIFF
--- a/src/ImageSharp.Web/Commands/PresetOnlyQueryCollectionRequestParser.cs
+++ b/src/ImageSharp.Web/Commands/PresetOnlyQueryCollectionRequestParser.cs
@@ -39,7 +39,8 @@ namespace SixLabors.ImageSharp.Web.Commands
                 return new();
             }
 
-            string requestedPreset = context.Request.Query[QueryKey][0];
+            StringValues query = context.Request.Query[QueryKey];
+            string requestedPreset = query[query.Count - 1];
             if (this.presets.TryGetValue(requestedPreset, out CommandCollection collection))
             {
                 return collection;
@@ -63,7 +64,8 @@ namespace SixLabors.ImageSharp.Web.Commands
             CommandCollection transformed = new();
             foreach (KeyValuePair<string, StringValues> pair in parsed)
             {
-                transformed.Add(new(pair.Key, pair.Value.ToString()));
+                // Use the indexer for both set and query. This replaces any previously parsed values.
+                transformed[pair.Key] = pair.Value[pair.Value.Count - 1];
             }
 
             return transformed;

--- a/src/ImageSharp.Web/Commands/QueryCollectionRequestParser.cs
+++ b/src/ImageSharp.Web/Commands/QueryCollectionRequestParser.cs
@@ -28,7 +28,8 @@ namespace SixLabors.ImageSharp.Web.Commands
             CommandCollection transformed = new();
             foreach (KeyValuePair<string, StringValues> pair in parsed)
             {
-                transformed.Add(new(pair.Key, pair.Value.ToString()));
+                // Use the indexer for both set and query. This replaces any previously parsed values.
+                transformed[pair.Key] = pair.Value[pair.Value.Count - 1];
             }
 
             return transformed;

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.2" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -212,17 +212,13 @@ namespace SixLabors.ImageSharp.Web.Middleware
             if (commands.Count > 0)
             {
                 // Strip out any unknown commands, if needed.
-                int index = 0;
-                foreach (string command in commands.Keys)
+                var keys = new List<string>(commands.Keys);
+                for (int i = keys.Count - 1; i >= 0; i--)
                 {
-                    if (!this.knownCommands.Contains(command))
+                    if (!this.knownCommands.Contains(keys[i]))
                     {
-                        // Need to actually remove, allocates new list to allow modifications
-                        this.StripUnknownCommands(commands, index);
-                        break;
+                        commands.RemoveAt(i);
                     }
-
-                    index++;
                 }
             }
 
@@ -305,19 +301,6 @@ namespace SixLabors.ImageSharp.Web.Middleware
             // We don't log the error to avoid attempts at log poisoning.
             httpContext.Response.Clear();
             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-        }
-
-        private void StripUnknownCommands(CommandCollection commands, int startAtIndex)
-        {
-            var keys = new List<string>(commands.Keys);
-            for (int index = startAtIndex; index < keys.Count; index++)
-            {
-                string command = keys[index];
-                if (!this.knownCommands.Contains(command))
-                {
-                    commands.Remove(command);
-                }
-            }
         }
 
         private async Task ProcessRequestAsync(

--- a/tests/ImageSharp.Web.Tests/Commands/CommandCollectionTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/CommandCollectionTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using System.Collections.Generic;
 using SixLabors.ImageSharp.Web.Commands;
 using Xunit;
@@ -14,6 +15,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
         {
             CommandCollection collection = new();
             collection.Add(new("a", "b"));
+            Assert.Single(collection);
+        }
+
+        [Fact]
+        public void CannotAddDuplicateCommands()
+        {
+            CommandCollection collection = new();
+            collection.Add(new("a", "b"));
+            Assert.Throws<ArgumentException>(() => collection.Add(new("a", "b")));
             Assert.Single(collection);
         }
 
@@ -49,6 +59,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
         }
 
         [Fact]
+        public void CannotInsertDuplicateCommands()
+        {
+            CommandCollection collection = new();
+            collection.Add(new("a", "b"));
+            Assert.Throws<ArgumentException>(() => collection.Insert(0, new("a", "b")));
+            Assert.Single(collection);
+        }
+
+        [Fact]
         public void CanInsertCommandsViaKey()
         {
             KeyValuePair<string, string> kv1 = new("a", "b");
@@ -66,6 +85,15 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
 
             Assert.Equal(1, collection.IndexOf(kv1));
             Assert.Equal(0, collection.IndexOf(kv2));
+        }
+
+        [Fact]
+        public void CannotInsertDuplicateCommandsViaKey()
+        {
+            CommandCollection collection = new();
+            collection.Add(new("a", "b"));
+            Assert.Throws<ArgumentException>(() => collection.Insert(0, "a", "b"));
+            Assert.Single(collection);
         }
 
         [Fact]

--- a/tests/ImageSharp.Web.Tests/Commands/QueryCollectionUriParserTests.cs
+++ b/tests/ImageSharp.Web.Tests/Commands/QueryCollectionUriParserTests.cs
@@ -28,7 +28,9 @@ namespace SixLabors.ImageSharp.Web.Tests.Commands
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Path = "/testwebsite.com/image-12345.jpeg";
-            httpContext.Request.QueryString = new QueryString("?width=400&height=200");
+
+            // Duplicate height param to test replacements
+            httpContext.Request.QueryString = new QueryString("?width=400&height=100&height=200");
             return httpContext;
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

This PR does a few things
- Prevents multiple enumeration of comand keys and removes invalid commands in a single loop.
- Allows duplicate commands in the URL (_avoiding ArgumentException_), taking and parsing only the last one. (_Duplicates are not counted in cache key generation as that happens following stripping_)
- Update ImageSharp to v2.1.2

<!-- Thanks for contributing to ImageSharp! -->
