### PR TITLE
Added a check when forbidden is returned from S3 bucket

### DIFF
--- a/src/ImageSharp.Web.Providers.AWS/Providers/AWSS3StorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Providers/AWSS3StorageImageProvider.cs
@@ -161,6 +161,12 @@ namespace SixLabors.ImageSharp.Web.Providers.AWS
                     return false;
                 }
 
+                // If the object exists but the client is not authorized to access it, then a "Forbidden" will be thrown.
+                if (string.Equals(e.ErrorCode, "Forbidden"))
+                {
+                    return false;
+                }
+
                 throw;
             }
         }


### PR DESCRIPTION
…sts in a S3 Bucket.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
We don't need the `ListBucket` permission when accessing the S3 bucket. We will always know the key we want to access, but the side effect is we are getting a Forbidden from the S3 bucket, probably to prevent bucket enumeration. I think it's safe to assume that the Key doesn't exist.

<!-- Thanks for contributing to ImageSharp! -->
