### PR TITLE
Drop .NET Core 2.1 to fix Azure dependency security issue

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,18 +28,6 @@ jobs:
             runtime: -x64
             codecov: true
           - os: ubuntu-latest
-            framework: net5.0
-            runtime: -x64
-            codecov: false
-          - os: macos-latest
-            framework: net5.0
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: net5.0
-            runtime: -x64
-            codecov: false
-          - os: ubuntu-latest
             framework: netcoreapp3.1
             runtime: -x64
             codecov: false
@@ -49,10 +37,6 @@ jobs:
             codecov: false
           - os: windows-latest
             framework: netcoreapp3.1
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: netcoreapp2.1
             runtime: -x64
             codecov: false
 
@@ -129,9 +113,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            5.0.x
             3.1.x
-            2.1.x
 
       - name: DotNet Build
         shell: pwsh

--- a/src/ImageSharp.Web.Providers.AWS/ImageSharp.Web.Providers.AWS.csproj
+++ b/src/ImageSharp.Web.Providers.AWS/ImageSharp.Web.Providers.AWS.csproj
@@ -16,12 +16,12 @@
   <Choose>
     <When Condition="$(SIXLABORS_TESTING) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/ImageSharp.Web.Providers.Azure/ImageSharp.Web.Providers.Azure.csproj
+++ b/src/ImageSharp.Web.Providers.Azure/ImageSharp.Web.Providers.Azure.csproj
@@ -16,12 +16,12 @@
   <Choose>
     <When Condition="$(SIXLABORS_TESTING) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -31,8 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--TODO: Do not upgrade this. Last Version that supports .NET Core 2.1-->
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
+++ b/src/ImageSharp.Web/Caching/PhysicalFileSystemCache.cs
@@ -40,11 +40,7 @@ namespace SixLabors.ImageSharp.Web.Caching
         /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
         public PhysicalFileSystemCache(
             IOptions<PhysicalFileSystemCacheOptions> options,
-#if NETCOREAPP2_1
-            IHostingEnvironment environment,
-#else
             IWebHostEnvironment environment,
-#endif
             FormatUtilities formatUtilities)
         {
             Guard.NotNull(options, nameof(options));

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -16,12 +16,12 @@
   <Choose>
     <When Condition="$(SIXLABORS_TESTING) == true">
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -30,22 +30,8 @@
     <None Include="..\..\shared-infrastructure\branding\icons\imagesharp.web\sixlabors.imagesharp.web.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>

--- a/src/ImageSharp.Web/ImageSharpRequestAuthorizationUtilities.cs
+++ b/src/ImageSharp.Web/ImageSharpRequestAuthorizationUtilities.cs
@@ -6,11 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-
-#if !NETCOREAPP3_0_OR_GREATER
-using Microsoft.AspNetCore.Http.Internal;
-#endif
-
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp.Web.Commands;

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -449,19 +449,7 @@ namespace SixLabors.ImageSharp.Web.Middleware
                 return default;
             }
 
-#if NETCOREAPP2_1
-            try
-            {
-                stream.Dispose();
-                return default;
-            }
-            catch (Exception ex)
-            {
-                return new ValueTask(Task.FromException(ex));
-            }
-#else
             return stream.DisposeAsync();
-#endif
         }
 
         private async Task<ImageWorkerResult> IsNewOrUpdatedAsync(

--- a/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
+++ b/src/ImageSharp.Web/Providers/PhysicalFileSystemProvider.cs
@@ -22,11 +22,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
         public PhysicalFileSystemProvider(
             IOptions<PhysicalFileSystemProviderOptions> options,
-#if NETCOREAPP2_1
-            IHostingEnvironment environment,
-#else
             IWebHostEnvironment environment,
-#endif
             FormatUtilities formatUtilities)
             : base(GetProvider(options, environment), options.Value.ProcessingBehavior, formatUtilities)
         {
@@ -58,11 +54,7 @@ namespace SixLabors.ImageSharp.Web.Providers
 
         private static PhysicalFileProvider GetProvider(
             IOptions<PhysicalFileSystemProviderOptions> options,
-#if NETCOREAPP2_1
-            IHostingEnvironment environment)
-#else
             IWebHostEnvironment environment)
-#endif
         {
             Guard.NotNull(options, nameof(options));
             Guard.NotNull(environment, nameof(environment));

--- a/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
+++ b/src/ImageSharp.Web/Providers/WebRootImageProvider.cs
@@ -16,11 +16,7 @@ namespace SixLabors.ImageSharp.Web.Providers
         /// <param name="environment">The web hosting environment.</param>
         /// <param name="formatUtilities">Contains various format helper methods based on the current configuration.</param>
         public WebRootImageProvider(
-#if NETCOREAPP2_1
-            IHostingEnvironment environment,
-#else
             IWebHostEnvironment environment,
-#endif
             FormatUtilities formatUtilities)
             : base(environment.WebRootFileProvider, ProcessingBehavior.CommandOnly, formatUtilities)
         {

--- a/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
+++ b/src/ImageSharp.Web/Synchronization/RefCountedConcurrentDictionary.cs
@@ -229,10 +229,8 @@ namespace SixLabors.ImageSharp.Web.Synchronization
             public bool Equals(
 #if NET5_0_OR_GREATER
                 RefCountedValue? other)
-#elif NETCOREAPP3_1_OR_GREATER
-                [System.Diagnostics.CodeAnalysis.AllowNull] RefCountedValue other)
 #else
-                RefCountedValue other)
+                [System.Diagnostics.CodeAnalysis.AllowNull] RefCountedValue other)
 #endif
                 => (other != null) && (this.RefCount == other.RefCount) && EqualityComparer<TValue>.Default.Equals(this.Value, other.Value);
 

--- a/tests/ImageSharp.Web.Benchmarks/ImageSharp.Web.Benchmarks.csproj
+++ b/tests/ImageSharp.Web.Benchmarks/ImageSharp.Web.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>ImageSharp.Web.Benchmarks</AssemblyName>
     <RootNamespace>SixLabors.ImageSharp.Web.Benchmarks</RootNamespace>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -14,8 +14,4 @@
     <PackageReference Include="BenchmarkDotNet"/>
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Http"/>
-  </ItemGroup>
-
 </Project>

--- a/tests/ImageSharp.Web.Tests/ImageSharp.Web.Tests.csproj
+++ b/tests/ImageSharp.Web.Tests/ImageSharp.Web.Tests.csproj
@@ -3,15 +3,10 @@
   <PropertyGroup>
     <RootNamespace>SixLabors.ImageSharp.Web.Tests</RootNamespace>
     <AssemblyName>SixLabors.ImageSharp.Web.Tests</AssemblyName>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Http" />
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
   </ItemGroup>
 

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AWSS3StorageImageProviderFactory.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AWSS3StorageImageProviderFactory.cs
@@ -70,11 +70,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
                 }
             }
 
-#if NETCOREAPP2_1
-            IHostingEnvironment environment = services.GetRequiredService<IHostingEnvironment>();
-#else
             IWebHostEnvironment environment = services.GetRequiredService<IWebHostEnvironment>();
-#endif
 
             try
             {

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageImageProviderFactory.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageImageProviderFactory.cs
@@ -33,11 +33,7 @@ namespace SixLabors.ImageSharp.Web.Tests.TestUtilities
             var container = new BlobContainerClient(containerOptions.ConnectionString, containerOptions.ContainerName);
             container.CreateIfNotExists(PublicAccessType.Blob);
 
-#if NETCOREAPP2_1
-            IHostingEnvironment environment = services.GetRequiredService<IHostingEnvironment>();
-#else
             IWebHostEnvironment environment = services.GetRequiredService<IWebHostEnvironment>();
-#endif
 
             BlobClient blob = container.GetBlobClient(TestConstants.ImagePath);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
See #284 (Dependabot)

We have a security issue in the Azure Dependency and are unable to upgrade to mitigate the issue without removing support for .NET Core 2.. Since that target framework is long obsolete I've chosen to do this without a major update. The next version will be v2.1.0 



<!-- Thanks for contributing to ImageSharp! -->
