### PR TITLE
Add Parsing of TargetRectangle to ResizeWebProcessor

### DIFF
--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -62,16 +62,6 @@ public class ResizeWebProcessor : IImageWebProcessor
     /// </summary>
     public const string Compand = "compand";
 
-    /// <summary>
-    /// The command constant for the resize TargetRectangle X
-    /// </summary>
-    public const string TargetRectangleWidth = "targetrectanglewidth";
-
-    /// <summary>
-    /// The command constant for the resize TargetRectangle X
-    /// </summary>
-    public const string TargetRectangleHeight = "targetrectangleheight";
-
     private static readonly IEnumerable<string> ResizeCommands
         = new[]
         {
@@ -137,18 +127,18 @@ public class ResizeWebProcessor : IImageWebProcessor
             return null;
         }
 
-        Rectangle? targetRectangle = ParseRectangle(commands, parser, culture);
+        ResizeMode mode = GetMode(commands, parser, culture);
 
         return new()
         {
             Size = size,
             CenterCoordinates = GetCenter(orientation, commands, parser, culture),
             Position = GetAnchor(orientation, commands, parser, culture),
-            Mode = GetMode(commands, parser, culture),
+            Mode = mode,
             Compand = GetCompandMode(commands, parser, culture),
             Sampler = GetSampler(commands),
             PadColor = parser.ParseValue<Color>(commands.GetValueOrDefault(Color), culture),
-            TargetRectangle = targetRectangle
+            TargetRectangle = mode is ResizeMode.Manual ? new Rectangle(0, 0, size.Width, size.Height) : null
         };
     }
 
@@ -170,23 +160,6 @@ public class ResizeWebProcessor : IImageWebProcessor
         int height = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(Height), culture);
 
         return ExifOrientationUtilities.Transform(new Size(width, height), orientation);
-    }
-
-    private static Rectangle? ParseRectangle(
-        CommandCollection commands,
-        CommandParser parser,
-        CultureInfo culture)
-    {
-        if (!commands.Contains(TargetRectangleWidth) || !commands.Contains(TargetRectangleHeight))
-        {
-            return null;
-        }
-
-        // The command parser will reject negative numbers as it clamps values to ranges.
-        int width = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(TargetRectangleWidth), culture);
-        int height = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(TargetRectangleHeight), culture);
-
-        return new Rectangle(0, 0, width, height);
     }
 
     private static PointF? GetCenter(

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -65,16 +65,6 @@ public class ResizeWebProcessor : IImageWebProcessor
     /// <summary>
     /// The command constant for the resize TargetRectangle X
     /// </summary>
-    public const string TargetRectangleX = "targetrectanglex";
-
-    /// <summary>
-    /// The command constant for the resize TargetRectangle X
-    /// </summary>
-    public const string TargetRectangleY = "targetrectangley";
-
-    /// <summary>
-    /// The command constant for the resize TargetRectangle X
-    /// </summary>
     public const string TargetRectangleWidth = "targetrectanglewidth";
 
     /// <summary>
@@ -196,15 +186,7 @@ public class ResizeWebProcessor : IImageWebProcessor
         int width = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(TargetRectangleWidth), culture);
         int height = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(TargetRectangleHeight), culture);
 
-        if (!commands.Contains(TargetRectangleX) || !commands.Contains(TargetRectangleY))
-        {
-            return new Rectangle(0, 0, width, height);
-        }
-
-        int x = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(TargetRectangleX), culture);
-        int y = (int)parser.ParseValue<uint>(commands.GetValueOrDefault(TargetRectangleY), culture);
-
-        return new Rectangle(x, y, width, height);
+        return new Rectangle(0, 0, width, height);
     }
 
     private static PointF? GetCenter(


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Adds the ability to specify the targetrectangle in the commands. As asked in #302 