### PR TITLE
Updated the `KeyExists` from aws to keep the response metadata in the image resolver

### DIFF
--- a/src/ImageSharp.Web.Providers.AWS/Providers/AWSS3StorageImageProvider.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Providers/AWSS3StorageImageProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
+#nullable disable
 
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -28,7 +29,7 @@ public class AWSS3StorageImageProvider : IImageProvider
         = new();
 
     private readonly AWSS3StorageImageProviderOptions storageOptions;
-    private Func<HttpContext, bool>? match;
+    private Func<HttpContext, bool> match;
 
     /// <summary>
     /// Contains various helper methods based on the current configuration.
@@ -69,23 +70,17 @@ public class AWSS3StorageImageProvider : IImageProvider
         => this.formatUtilities.TryGetExtensionFromUri(context.Request.GetDisplayUrl(), out _);
 
     /// <inheritdoc />
-    public async Task<IImageResolver?> GetAsync(HttpContext context)
+    public async Task<IImageResolver> GetAsync(HttpContext context)
     {
         // Strip the leading slash and bucket name from the HTTP request path and treat
         // the remaining path string as the key.
         // Path has already been correctly parsed before here.
         string bucketName = string.Empty;
-        IAmazonS3? s3Client = null;
+        IAmazonS3 s3Client = null;
 
         // We want an exact match here to ensure that bucket names starting with
         // the same prefix are not mixed up.
-        string? path = context.Request.Path.Value?.TrimStart(SlashChars);
-
-        if (path is null)
-        {
-            return null;
-        }
-
+        string path = context.Request.Path.Value.TrimStart(SlashChars);
         int index = path.IndexOfAny(SlashChars);
         string nameToMatch = index != -1 ? path.Substring(0, index) : path;
 
@@ -126,13 +121,7 @@ public class AWSS3StorageImageProvider : IImageProvider
     {
         // Only match loosly here for performance.
         // Path matching conflicts should be dealt with by configuration.
-        string? path = context.Request.Path.Value?.TrimStart(SlashChars);
-
-        if (path is null)
-        {
-            return false;
-        }
-
+        string path = context.Request.Path.Value.TrimStart(SlashChars);
         foreach (string bucket in this.buckets.Keys)
         {
             if (path.StartsWith(bucket, StringComparison.OrdinalIgnoreCase))
@@ -177,7 +166,7 @@ public class AWSS3StorageImageProvider : IImageProvider
         }
     }
 
-    private readonly record struct KeyExistsResult(GetObjectMetadataResponse? Metadata)
+    private readonly record struct KeyExistsResult(GetObjectMetadataResponse Metadata)
     {
         public bool Exists => this.Metadata is not null;
     }

--- a/src/ImageSharp.Web.Providers.AWS/Resolvers/AWSS3StorageImageResolver.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Resolvers/AWSS3StorageImageResolver.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
+#nullable disable
 
 using System.Net.Http.Headers;
 using Amazon.S3;
@@ -15,7 +16,7 @@ public class AWSS3StorageImageResolver : IImageResolver
     private readonly IAmazonS3 amazonS3;
     private readonly string bucketName;
     private readonly string imagePath;
-    private readonly GetObjectMetadataResponse? metadataResponse;
+    private readonly GetObjectMetadataResponse metadataResponse;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AWSS3StorageImageResolver"/> class.
@@ -24,7 +25,7 @@ public class AWSS3StorageImageResolver : IImageResolver
     /// <param name="bucketName">The bucket name.</param>
     /// <param name="imagePath">The image path.</param>
     /// <param name="metadataResponse">Optional metadata response.</param>
-    public AWSS3StorageImageResolver(IAmazonS3 amazonS3, string bucketName, string imagePath, GetObjectMetadataResponse? metadataResponse = null)
+    public AWSS3StorageImageResolver(IAmazonS3 amazonS3, string bucketName, string imagePath, GetObjectMetadataResponse metadataResponse = null)
     {
         this.amazonS3 = amazonS3;
         this.bucketName = bucketName;
@@ -40,7 +41,7 @@ public class AWSS3StorageImageResolver : IImageResolver
         // Try to parse the max age from the source. If it's not zero then we pass it along
         // to set the cache control headers for the response.
         TimeSpan maxAge = TimeSpan.MinValue;
-        if (CacheControlHeaderValue.TryParse(metadata.Headers.CacheControl, out CacheControlHeaderValue? cacheControl))
+        if (CacheControlHeaderValue.TryParse(metadata.Headers.CacheControl, out CacheControlHeaderValue cacheControl))
         {
             // Weirdly passing null to TryParse returns true.
             if (cacheControl?.MaxAge.HasValue == true)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
When the image is resolved we validate if it exists with the method `KeyExists`. To validate this the methods fetch all the object metadata, if it fails it's considered not existent, but the result of that query isn't used.
This PR keeps the result and pass it to the AWS S3 image resolver.
I added an optional parameter for that metadata, in case the resolver needs to be build it elsewhere. If the metadata is not provided, it will fetch it like it used to.

Since I had overlapped change with https://github.com/SixLabors/ImageSharp.Web/pull/312, I included the change of those files in my PR to limit the conflicts and use the nullable options ;)


<!-- Thanks for contributing to ImageSharp! -->
