### PR TITLE
Use a single pipeline for images.

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -27,7 +27,7 @@ public class ImageSharpMiddlewareOptions
     };
 
     private Func<ImageCommandContext, Task> onParseCommandsAsync = _ => Task.CompletedTask;
-    private Func<HttpContext, DecoderOptions, Task> onBeforeLoadAsync = (_, _) => Task.CompletedTask;
+    private Func<ImageCommandContext, DecoderOptions, Task> onBeforeLoadAsync = (_, _) => Task.CompletedTask;
     private Func<FormattedImage, Task> onBeforeSaveAsync = _ => Task.CompletedTask;
     private Func<ImageProcessingContext, Task> onProcessedAsync = _ => Task.CompletedTask;
     private Func<HttpContext, Task> onPrepareResponseAsync = _ => Task.CompletedTask;
@@ -118,7 +118,7 @@ public class ImageSharpMiddlewareOptions
     /// Gets or sets the method that can be used to used to augment decoder options.
     /// This is called before the image is decoded and loaded for processing.
     /// </summary>
-    public Func<HttpContext, DecoderOptions, Task> OnBeforeLoadAsync
+    public Func<ImageCommandContext, DecoderOptions, Task> OnBeforeLoadAsync
     {
         get => this.onBeforeLoadAsync;
 

--- a/tests/ImageSharp.Web.Tests/TestUtilities/TestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/TestServerFixture.cs
@@ -68,7 +68,7 @@ public abstract class TestServerFixture : IDisposable
                 return onParseCommandsAsync.Invoke(context);
             };
 
-            Func<HttpContext, DecoderOptions, Task> onBeforeLoadAsync = options.OnBeforeLoadAsync;
+            Func<ImageCommandContext, DecoderOptions, Task> onBeforeLoadAsync = options.OnBeforeLoadAsync;
 
             options.OnBeforeLoadAsync = (context, decoderOptions) =>
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Removes the copy-only pipeline for images without commands to fix #316 

<!-- Thanks for contributing to ImageSharp! -->
