### PR TITLE
Fix DecoderOptions handler.

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -343,10 +343,9 @@ public class ImageSharpMiddleware
 
                         using (Stream inStream = await sourceImageResolver.OpenReadAsync())
                         {
-                            DecoderOptions decoderOptions = new() { Configuration = this.options.Configuration };
-
                             // TODO: Do we need some way to set options based upon processors?
-                            await this.options.OnBeforeLoadAsync.Invoke(imageCommandContext, decoderOptions);
+                            DecoderOptions decoderOptions = await this.options.OnBeforeLoadAsync.Invoke(imageCommandContext, this.options.Configuration)
+                                ?? new() { Configuration = this.options.Configuration };
 
                             FormattedImage? image = null;
                             try

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -27,7 +27,7 @@ public class ImageSharpMiddlewareOptions
     };
 
     private Func<ImageCommandContext, Task> onParseCommandsAsync = _ => Task.CompletedTask;
-    private Func<ImageCommandContext, DecoderOptions, Task> onBeforeLoadAsync = (_, _) => Task.CompletedTask;
+    private Func<ImageCommandContext, Configuration, Task<DecoderOptions?>> onBeforeLoadAsync = (_, _) => Task.FromResult<DecoderOptions?>(null);
     private Func<FormattedImage, Task> onBeforeSaveAsync = _ => Task.CompletedTask;
     private Func<ImageProcessingContext, Task> onProcessedAsync = _ => Task.CompletedTask;
     private Func<HttpContext, Task> onPrepareResponseAsync = _ => Task.CompletedTask;
@@ -118,7 +118,7 @@ public class ImageSharpMiddlewareOptions
     /// Gets or sets the method that can be used to used to augment decoder options.
     /// This is called before the image is decoded and loaded for processing.
     /// </summary>
-    public Func<ImageCommandContext, DecoderOptions, Task> OnBeforeLoadAsync
+    public Func<ImageCommandContext, Configuration, Task<DecoderOptions?>> OnBeforeLoadAsync
     {
         get => this.onBeforeLoadAsync;
 

--- a/tests/ImageSharp.Web.Tests/TestUtilities/TestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/TestServerFixture.cs
@@ -68,14 +68,14 @@ public abstract class TestServerFixture : IDisposable
                 return onParseCommandsAsync.Invoke(context);
             };
 
-            Func<ImageCommandContext, DecoderOptions, Task> onBeforeLoadAsync = options.OnBeforeLoadAsync;
+            Func<ImageCommandContext, Configuration, Task<DecoderOptions?>> onBeforeLoadAsync = options.OnBeforeLoadAsync;
 
-            options.OnBeforeLoadAsync = (context, decoderOptions) =>
+            options.OnBeforeLoadAsync = (context, configuration) =>
             {
                 Assert.NotNull(context);
-                Assert.NotNull(decoderOptions);
+                Assert.NotNull(configuration);
 
-                return onBeforeLoadAsync.Invoke(context, decoderOptions);
+                return onBeforeLoadAsync.Invoke(context, configuration);
             };
 
             Func<ImageProcessingContext, Task> onProcessedAsync = options.OnProcessedAsync;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
The current `OnBeforeLoadAsync` delegate is useless as `DecoderOptions` properties are init-only. This PR includes an emergency breaking change which updates the method to return options themselves.

<!-- Thanks for contributing to ImageSharp! -->
