### PR TITLE
Remove async HMAC operations.

### DIFF
--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -228,9 +228,9 @@ public class ImageSharpMiddleware
             //
             // As a rule all image requests should contain valid commands only.
             // Key generation uses string.Create under the hood with very low allocation so should be good enough as a cache key.
-            hmac = await HMACTokenLru.GetOrAddAsync(
+            hmac = HMACTokenLru.GetOrAdd(
                 httpContext.Request.GetEncodedUrl(),
-                _ => this.authorizationUtilities.ComputeHMACAsync(imageCommandContext));
+                _ => this.authorizationUtilities.ComputeHMAC(imageCommandContext));
         }
 
         await this.options.OnParseCommandsAsync.Invoke(imageCommandContext);

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -15,7 +15,7 @@ namespace SixLabors.ImageSharp.Web.Middleware;
 /// </summary>
 public class ImageSharpMiddlewareOptions
 {
-    private Func<ImageCommandContext, byte[], Task<string>> onComputeHMACAsync = (context, secret) =>
+    private Func<ImageCommandContext, byte[], string> onComputeHMAC = (context, secret) =>
     {
         string uri = CaseHandlingUriBuilder.BuildRelative(
              CaseHandlingUriBuilder.CaseHandling.LowerInvariant,
@@ -23,7 +23,7 @@ public class ImageSharpMiddlewareOptions
              context.Context.Request.Path,
              QueryString.Create(context.Commands));
 
-        return Task.FromResult(HMACUtilities.ComputeHMACSHA256(uri, secret));
+        return HMACUtilities.ComputeHMACSHA256(uri, secret);
     };
 
     private Func<ImageCommandContext, Task> onParseCommandsAsync = _ => Task.CompletedTask;
@@ -88,14 +88,14 @@ public class ImageSharpMiddlewareOptions
     /// Defaults to <see cref="HMACUtilities.ComputeHMACSHA256(string, byte[])"/> using an invariant lowercase relative Uri
     /// generated using <see cref="CaseHandlingUriBuilder.BuildRelative(CaseHandlingUriBuilder.CaseHandling, PathString, PathString, QueryString)"/>.
     /// </summary>
-    public Func<ImageCommandContext, byte[], Task<string>> OnComputeHMACAsync
+    public Func<ImageCommandContext, byte[], string> OnComputeHMAC
     {
-        get => this.onComputeHMACAsync;
+        get => this.onComputeHMAC;
 
         set
         {
-            Guard.NotNull(value, nameof(this.onComputeHMACAsync));
-            this.onComputeHMACAsync = value;
+            Guard.NotNull(value, nameof(this.onComputeHMAC));
+            this.onComputeHMAC = value;
         }
     }
 

--- a/src/ImageSharp.Web/RequestAuthorizationUtilities.cs
+++ b/src/ImageSharp.Web/RequestAuthorizationUtilities.cs
@@ -104,15 +104,6 @@ public sealed class RequestAuthorizationUtilities
     /// <param name="uri">The uri to compute the code from.</param>
     /// <param name="handling">The command collection handling.</param>
     /// <returns>The computed HMAC.</returns>
-    public Task<string?> ComputeHMACAsync(string uri, CommandHandling handling)
-        => this.ComputeHMACAsync(new Uri(uri, UriKind.RelativeOrAbsolute), handling);
-
-    /// <summary>
-    /// Compute a Hash-based Message Authentication Code (HMAC) for request authentication.
-    /// </summary>
-    /// <param name="uri">The uri to compute the code from.</param>
-    /// <param name="handling">The command collection handling.</param>
-    /// <returns>The computed HMAC.</returns>
     public string? ComputeHMAC(Uri uri, CommandHandling handling)
     {
         ToComponents(
@@ -122,23 +113,6 @@ public sealed class RequestAuthorizationUtilities
             out QueryString queryString);
 
         return this.ComputeHMAC(host, path, queryString, handling);
-    }
-
-    /// <summary>
-    /// Compute a Hash-based Message Authentication Code (HMAC) for request authentication.
-    /// </summary>
-    /// <param name="uri">The uri to compute the code from.</param>
-    /// <param name="handling">The command collection handling.</param>
-    /// <returns>The computed HMAC.</returns>
-    public Task<string?> ComputeHMACAsync(Uri uri, CommandHandling handling)
-    {
-        ToComponents(
-            uri,
-            out HostString host,
-            out PathString path,
-            out QueryString queryString);
-
-        return this.ComputeHMACAsync(host, path, queryString, handling);
     }
 
     /// <summary>
@@ -158,17 +132,6 @@ public sealed class RequestAuthorizationUtilities
     /// <param name="host">The host header.</param>
     /// <param name="path">The path or pathbase.</param>
     /// <param name="queryString">The querystring.</param>
-    /// <param name="handling">The command collection handling.</param>
-    /// <returns>The computed HMAC.</returns>
-    public Task<string?> ComputeHMACAsync(HostString host, PathString path, QueryString queryString, CommandHandling handling)
-        => this.ComputeHMACAsync(host, path, queryString, new(QueryHelpers.ParseQuery(queryString.Value)), handling);
-
-    /// <summary>
-    /// Compute a Hash-based Message Authentication Code (HMAC) for request authentication.
-    /// </summary>
-    /// <param name="host">The host header.</param>
-    /// <param name="path">The path or pathbase.</param>
-    /// <param name="queryString">The querystring.</param>
     /// <param name="query">The query collection.</param>
     /// <param name="handling">The command collection handling.</param>
     /// <returns>The computed HMAC.</returns>
@@ -178,31 +141,10 @@ public sealed class RequestAuthorizationUtilities
     /// <summary>
     /// Compute a Hash-based Message Authentication Code (HMAC) for request authentication.
     /// </summary>
-    /// <param name="host">The host header.</param>
-    /// <param name="path">The path or pathbase.</param>
-    /// <param name="queryString">The querystring.</param>
-    /// <param name="query">The query collection.</param>
-    /// <param name="handling">The command collection handling.</param>
-    /// <returns>The computed HMAC.</returns>
-    public Task<string?> ComputeHMACAsync(HostString host, PathString path, QueryString queryString, QueryCollection query, CommandHandling handling)
-        => this.ComputeHMACAsync(this.ToHttpContext(host, path, queryString, query), handling);
-
-    /// <summary>
-    /// Compute a Hash-based Message Authentication Code (HMAC) for request authentication.
-    /// </summary>
     /// <param name="context">The request HTTP context.</param>
     /// <param name="handling">The command collection handling.</param>
     /// <returns>The computed HMAC.</returns>
     public string? ComputeHMAC(HttpContext context, CommandHandling handling)
-        => AsyncHelper.RunSync(() => this.ComputeHMACAsync(context, handling));
-
-    /// <summary>
-    /// Compute a Hash-based Message Authentication Code (HMAC) for request authentication.
-    /// </summary>
-    /// <param name="context">The request HTTP context.</param>
-    /// <param name="handling">The command collection handling.</param>
-    /// <returns>The computed HMAC.</returns>
-    public async Task<string?> ComputeHMACAsync(HttpContext context, CommandHandling handling)
     {
         byte[] secret = this.options.HMACSecretKey;
         if (secret is null || secret.Length == 0)
@@ -222,7 +164,7 @@ public sealed class RequestAuthorizationUtilities
         }
 
         ImageCommandContext imageCommandContext = new(context, commands, this.commandParser, this.parserCulture);
-        return await this.options.OnComputeHMACAsync(imageCommandContext, secret);
+        return this.options.OnComputeHMAC(imageCommandContext, secret);
     }
 
     /// <summary>
@@ -234,14 +176,14 @@ public sealed class RequestAuthorizationUtilities
     /// </remarks>
     /// <param name="context">Contains information about the current image request and parsed commands.</param>
     /// <returns>The computed HMAC.</returns>
-    internal async Task<string?> ComputeHMACAsync(ImageCommandContext context)
+    internal string? ComputeHMAC(ImageCommandContext context)
     {
         if (context.Commands.Count == 0)
         {
             return null;
         }
 
-        return await this.options.OnComputeHMACAsync(context, this.options.HMACSecretKey);
+        return this.options.OnComputeHMAC(context, this.options.HMACSecretKey);
     }
 
     private static void ToComponents(

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AsyncHelper.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AsyncHelper.cs
@@ -3,7 +3,7 @@
 
 using System.Globalization;
 
-namespace SixLabors.ImageSharp.Web;
+namespace SixLabors.ImageSharp.Web.Tests.TestUtilities;
 
 /// <summary>
 /// <see href="https://github.com/aspnet/AspNetIdentity/blob/b7826741279450c58b230ece98bd04b4815beabf/src/Microsoft.AspNet.Identity.Core/AsyncHelper.cs"/>
@@ -20,7 +20,7 @@ internal static class AsyncHelper
     /// <summary>
     /// Executes an async <see cref="Task"/> method synchronously.
     /// </summary>
-    /// <param name="task">The task to excecute.</param>
+    /// <param name="task">The task to execute.</param>
     public static void RunSync(Func<Task> task)
     {
         CultureInfo cultureUi = CultureInfo.CurrentUICulture;
@@ -38,7 +38,7 @@ internal static class AsyncHelper
     /// a <paramref name="task"/> return type synchronously.
     /// </summary>
     /// <typeparam name="TResult">The type of result to return.</typeparam>
-    /// <param name="task">The task to excecute.</param>
+    /// <param name="task">The task to execute.</param>
     /// <returns>The <typeparamref name="TResult"/>.</returns>
     public static TResult RunSync<TResult>(Func<Task<TResult>> task)
     {

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AuthenticatedServerTestBase.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AuthenticatedServerTestBase.cs
@@ -11,7 +11,7 @@ public abstract class AuthenticatedServerTestBase<TFixture> : ServerTestBase<TFi
      where TFixture : AuthenticatedTestServerFixture
 {
     private readonly RequestAuthorizationUtilities authorizationUtilities;
-    private readonly string relativeImageSouce;
+    private readonly string relativeImageSource;
 
     protected AuthenticatedServerTestBase(TFixture fixture, ITestOutputHelper outputHelper, string imageSource)
         : base(fixture, outputHelper, imageSource)
@@ -19,7 +19,7 @@ public abstract class AuthenticatedServerTestBase<TFixture> : ServerTestBase<TFi
         this.authorizationUtilities =
                    this.Fixture.Services.GetRequiredService<RequestAuthorizationUtilities>();
 
-        this.relativeImageSouce = this.ImageSource.Replace("http://localhost", string.Empty);
+        this.relativeImageSource = this.ImageSource.Replace("http://localhost", string.Empty);
     }
 
     [Fact]
@@ -40,19 +40,17 @@ public abstract class AuthenticatedServerTestBase<TFixture> : ServerTestBase<TFi
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    protected override async Task<string> AugmentCommandAsync(string command)
+    protected override string AugmentCommand(string command)
     {
-        string uri = this.relativeImageSouce + command;
-        string token = await this.GetTokenAsync(uri);
+        string uri = this.relativeImageSource + command;
+        string token = this.GetToken(uri);
         return command + "&" + RequestAuthorizationUtilities.TokenCommand + "=" + token;
     }
 
-    private async Task<string> GetTokenAsync(string uri)
+    private string GetToken(string uri)
     {
         string tokenSync = this.authorizationUtilities.ComputeHMAC(uri, CommandHandling.Sanitize);
-        string tokenAsync = await this.authorizationUtilities.ComputeHMACAsync(uri, CommandHandling.Sanitize);
-
-        Assert.Equal(tokenSync, tokenAsync);
+        Assert.NotNull(tokenSync);
         return tokenSync;
     }
 }

--- a/tests/ImageSharp.Web.Tests/TestUtilities/ServerTestBase.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/ServerTestBase.cs
@@ -45,7 +45,7 @@ public abstract class ServerTestBase<TFixture> : IClassFixture<TFixture>
         Assert.True(Configuration.Default.ImageFormatsManager.TryFindFormatByFileExtension(ext, out IImageFormat format));
 
         // First response
-        HttpResponseMessage response = await this.HttpClient.GetAsync(url + await this.AugmentCommandAsync(this.Fixture.Commands[0]));
+        HttpResponseMessage response = await this.HttpClient.GetAsync(url + this.AugmentCommand(this.Fixture.Commands[0]));
 
         Assert.NotNull(response);
         Assert.True(response.IsSuccessStatusCode);
@@ -60,7 +60,7 @@ public abstract class ServerTestBase<TFixture> : IClassFixture<TFixture>
         response.Dispose();
 
         // Cached Response
-        response = await this.HttpClient.GetAsync(url + await this.AugmentCommandAsync(this.Fixture.Commands[0]));
+        response = await this.HttpClient.GetAsync(url + this.AugmentCommand(this.Fixture.Commands[0]));
 
         Assert.NotNull(response);
         Assert.True(response.IsSuccessStatusCode);
@@ -77,7 +77,7 @@ public abstract class ServerTestBase<TFixture> : IClassFixture<TFixture>
         // 304 response
         HttpRequestMessage request = new()
         {
-            RequestUri = new Uri(url + await this.AugmentCommandAsync(this.Fixture.Commands[0])),
+            RequestUri = new Uri(url + this.AugmentCommand(this.Fixture.Commands[0])),
             Method = HttpMethod.Get,
         };
 
@@ -100,7 +100,7 @@ public abstract class ServerTestBase<TFixture> : IClassFixture<TFixture>
         // 412 response
         request = new HttpRequestMessage
         {
-            RequestUri = new Uri(url + await this.AugmentCommandAsync(this.Fixture.Commands[0])),
+            RequestUri = new Uri(url + this.AugmentCommand(this.Fixture.Commands[0])),
             Method = HttpMethod.Get,
         };
 
@@ -119,8 +119,8 @@ public abstract class ServerTestBase<TFixture> : IClassFixture<TFixture>
     public async Task CanProcessMultipleIdenticalQueriesAsync()
     {
         string url = this.ImageSource;
-        string command1 = await this.AugmentCommandAsync(this.Fixture.Commands[0]);
-        string command2 = await this.AugmentCommandAsync(this.Fixture.Commands[1]);
+        string command1 = this.AugmentCommand(this.Fixture.Commands[0]);
+        string command2 = this.AugmentCommand(this.Fixture.Commands[1]);
 
         Task[] tasks = Enumerable.Range(0, 100).Select(i => Task.Run(async () =>
         {
@@ -136,5 +136,5 @@ public abstract class ServerTestBase<TFixture> : IClassFixture<TFixture>
         Assert.True(all.IsCompletedSuccessfully);
     }
 
-    protected virtual Task<string> AugmentCommandAsync(string command) => Task.FromResult(command);
+    protected virtual string AugmentCommand(string command) => command;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Removing the extremely performance harming async HMAC generation utilities from both `ImageSharpMiddlewareOptions` and `RequestAuthorizationUtilities`

See https://github.com/umbraco/Umbraco-CMS/pull/14364 for more information.

cc @nikolajlauridsen  @bergmania  @ronaldbarendse 

<!-- Thanks for contributing to ImageSharp! -->
