### PR TITLE
3.1 release compatibility 

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="feedz.io" value="https://f.feedz.io/sixlabors/sixlabors/nuget/index.json" />
-  </packageSources>
-</configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="feedz.io" value="https://f.feedz.io/sixlabors/sixlabors/nuget/index.json" />
+  </packageSources>
+</configuration>

--- a/src/ImageSharp.Web/ExifOrientationUtilities.cs
+++ b/src/ImageSharp.Web/ExifOrientationUtilities.cs
@@ -4,6 +4,7 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Processing;
 
 namespace SixLabors.ImageSharp.Web;
 

--- a/src/ImageSharp.Web/FormattedImage.cs
+++ b/src/ImageSharp.Web/FormattedImage.cs
@@ -2,9 +2,9 @@
 // Licensed under the Six Labors Split License.
 
 using System.Diagnostics.CodeAnalysis;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace SixLabors.ImageSharp.Web;
 
@@ -38,7 +38,7 @@ public sealed class FormattedImage : IDisposable
     private FormattedImage(Image image, IImageFormat format, bool keepOpen)
     {
         this.Image = image;
-        this.imageFormatsManager = image.GetConfiguration().ImageFormatsManager;
+        this.imageFormatsManager = image.Configuration.ImageFormatsManager;
         this.format = format;
         this.encoder = this.imageFormatsManager.GetEncoder(format);
         this.keepOpen = keepOpen;

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.0-alpha.0.43" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddleware.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IO;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Processors;

--- a/src/ImageSharp.Web/Processors/AutoOrientWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/AutoOrientWebProcessor.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Web.Commands;
 
 namespace SixLabors.ImageSharp.Web.Processors;

--- a/src/ImageSharp.Web/Processors/BackgroundColorWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/BackgroundColorWebProcessor.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Web.Commands;
 
 namespace SixLabors.ImageSharp.Web.Processors;

--- a/src/ImageSharp.Web/Processors/QualityWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/QualityWebProcessor.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using Microsoft.Extensions.Logging;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Web.Commands;
@@ -46,7 +45,7 @@ public class QualityWebProcessor : IImageWebProcessor
             {
                 JpegEncoder reference =
                     (JpegEncoder)image.Image
-                    .GetConfiguration()
+                    .Configuration
                     .ImageFormatsManager
                     .GetEncoder(image.Format);
 
@@ -65,7 +64,7 @@ public class QualityWebProcessor : IImageWebProcessor
             {
                 WebpEncoder reference =
                     (WebpEncoder)image.Image
-                    .GetConfiguration()
+                    .Configuration
                     .ImageFormatsManager
                     .GetEncoder(image.Format);
 

--- a/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
+++ b/src/ImageSharp.Web/Processors/ResizeWebProcessor.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Numerics;
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
 using SixLabors.ImageSharp.Web.Commands;
 

--- a/src/ImageSharp.Web/Resampler.cs
+++ b/src/ImageSharp.Web/Resampler.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using SixLabors.ImageSharp.Processing;
+
 namespace SixLabors.ImageSharp.Web;
 
 /// <summary>

--- a/src/ImageSharp.Web/TagHelpers/ImageTagHelper.cs
+++ b/src/ImageSharp.Web/TagHelpers/ImageTagHelper.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I need a fix in the 3.1 releases, sadly the alpha version of the `.Web` isn't compatible with the 3.1 release yet. I created this branch to fix the `using` in the `.Web` package.

- Added Feedz.io source for alpha builds
- Updated some using to work with 3.1 releases


<!-- Thanks for contributing to ImageSharp! -->
