### PR TITLE
Cache folder configuration for Azure and AWS Image Caches (Lombiq Technologies: OCORE-136)

### DIFF
--- a/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCache.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCache.cs
@@ -123,6 +123,9 @@ public class AWSS3StorageCache : IImageCache
         return null;
     }
 
+    private string GetKeyWithFolder(string key)
+        => this.cacheFolder + key;
+
     /// <summary>
     /// <see href="https://github.com/aspnet/AspNetIdentity/blob/b7826741279450c58b230ece98bd04b4815beabf/src/Microsoft.AspNet.Identity.Core/AsyncHelper.cs"/>
     /// </summary>
@@ -170,7 +173,4 @@ public class AWSS3StorageCache : IImageCache
             }).Unwrap().GetAwaiter().GetResult();
         }
     }
-
-    private string GetKeyWithFolder(string key)
-        => this.cacheFolder + key;
 }

--- a/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCache.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCache.cs
@@ -17,6 +17,7 @@ public class AWSS3StorageCache : IImageCache
 {
     private readonly IAmazonS3 amazonS3Client;
     private readonly string bucketName;
+    private readonly string cacheFolder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AWSS3StorageCache"/> class.
@@ -28,17 +29,21 @@ public class AWSS3StorageCache : IImageCache
         AWSS3StorageCacheOptions options = cacheOptions.Value;
         this.bucketName = options.BucketName;
         this.amazonS3Client = AmazonS3ClientFactory.CreateClient(options);
+        this.cacheFolder = string.IsNullOrEmpty(options.CacheFolder)
+            ? string.Empty
+            : options.CacheFolder.Trim().Trim('/') + '/';
     }
 
     /// <inheritdoc/>
     public async Task<IImageCacheResolver?> GetAsync(string key)
     {
-        GetObjectMetadataRequest request = new() { BucketName = this.bucketName, Key = key };
+        string keyWithFolder = this.GetKeyWithFolder(key);
+        GetObjectMetadataRequest request = new() { BucketName = this.bucketName, Key = keyWithFolder };
         try
         {
             // HEAD request throws a 404 if not found.
             MetadataCollection metadata = (await this.amazonS3Client.GetObjectMetadataAsync(request)).Metadata;
-            return new AWSS3StorageCacheResolver(this.amazonS3Client, this.bucketName, key, metadata);
+            return new AWSS3StorageCacheResolver(this.amazonS3Client, this.bucketName, keyWithFolder, metadata);
         }
         catch
         {
@@ -52,7 +57,7 @@ public class AWSS3StorageCache : IImageCache
         PutObjectRequest request = new()
         {
             BucketName = this.bucketName,
-            Key = key,
+            Key = this.GetKeyWithFolder(key),
             ContentType = metadata.ContentType,
             InputStream = stream,
             AutoCloseStream = false
@@ -165,4 +170,7 @@ public class AWSS3StorageCache : IImageCache
             }).Unwrap().GetAwaiter().GetResult();
         }
     }
+
+    private string GetKeyWithFolder(string key)
+        => this.cacheFolder + key;
 }

--- a/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCacheOptions.cs
@@ -17,7 +17,7 @@ public class AWSS3StorageCacheOptions : IAWSS3BucketClientOptions
     /// <summary>
     /// Gets or sets the cache folder's name that'll store cache files under the configured bucket.
     /// </summary>
-    public string CacheFolder { get; set; } = null!;
+    public string? CacheFolder { get; set; }
 
     /// <inheritdoc/>
     public string? AccessKey { get; set; }

--- a/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.AWS/Caching/AWSS3StorageCacheOptions.cs
@@ -14,6 +14,11 @@ public class AWSS3StorageCacheOptions : IAWSS3BucketClientOptions
     /// <inheritdoc/>
     public string BucketName { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the cache folder's name that'll store cache files under the configured bucket.
+    /// </summary>
+    public string CacheFolder { get; set; } = null!;
+
     /// <inheritdoc/>
     public string? AccessKey { get; set; }
 

--- a/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCache.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCache.cs
@@ -16,6 +16,7 @@ namespace SixLabors.ImageSharp.Web.Caching.Azure;
 public class AzureBlobStorageCache : IImageCache
 {
     private readonly BlobContainerClient container;
+    private readonly string cacheFolder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBlobStorageCache"/> class.
@@ -27,12 +28,15 @@ public class AzureBlobStorageCache : IImageCache
         AzureBlobStorageCacheOptions options = cacheOptions.Value;
 
         this.container = new BlobContainerClient(options.ConnectionString, options.ContainerName);
+        this.cacheFolder = string.IsNullOrEmpty(options.CacheFolder)
+            ? string.Empty
+            : options.CacheFolder.Trim().Trim('/') + '/';
     }
 
     /// <inheritdoc/>
     public async Task<IImageCacheResolver?> GetAsync(string key)
     {
-        BlobClient blob = this.container.GetBlobClient(key);
+        BlobClient blob = this.container.GetBlobClient(this.GetBlobName(key));
 
         if (!await blob.ExistsAsync())
         {
@@ -45,7 +49,7 @@ public class AzureBlobStorageCache : IImageCache
     /// <inheritdoc/>
     public Task SetAsync(string key, Stream stream, ImageCacheMetadata metadata)
     {
-        BlobClient blob = this.container.GetBlobClient(key);
+        BlobClient blob = this.container.GetBlobClient(this.GetBlobName(key));
 
         BlobHttpHeaders headers = new()
         {
@@ -79,4 +83,7 @@ public class AzureBlobStorageCache : IImageCache
         AzureBlobStorageCacheOptions options,
         PublicAccessType accessType)
         => new BlobContainerClient(options.ConnectionString, options.ContainerName).CreateIfNotExists(accessType);
+
+    private string GetBlobName(string key)
+        => this.cacheFolder + key;
 }

--- a/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCache.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCache.cs
@@ -36,7 +36,7 @@ public class AzureBlobStorageCache : IImageCache
     /// <inheritdoc/>
     public async Task<IImageCacheResolver?> GetAsync(string key)
     {
-        BlobClient blob = this.container.GetBlobClient(this.GetBlobName(key));
+        BlobClient blob = this.GetBlob(key);
 
         if (!await blob.ExistsAsync())
         {
@@ -49,7 +49,7 @@ public class AzureBlobStorageCache : IImageCache
     /// <inheritdoc/>
     public Task SetAsync(string key, Stream stream, ImageCacheMetadata metadata)
     {
-        BlobClient blob = this.container.GetBlobClient(this.GetBlobName(key));
+        BlobClient blob = this.GetBlob(key);
 
         BlobHttpHeaders headers = new()
         {
@@ -84,6 +84,6 @@ public class AzureBlobStorageCache : IImageCache
         PublicAccessType accessType)
         => new BlobContainerClient(options.ConnectionString, options.ContainerName).CreateIfNotExists(accessType);
 
-    private string GetBlobName(string key)
-        => this.cacheFolder + key;
+    private BlobClient GetBlob(string key)
+        => this.container.GetBlobClient(this.cacheFolder + key);
 }

--- a/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
@@ -16,8 +16,15 @@ public class AzureBlobStorageCacheOptions
 
     /// <summary>
     /// Gets or sets the Azure Blob Storage container name.
-    /// Must conform to Azure Blob Storage container naming guidlines.
+    /// Must conform to Azure Blob Storage container naming guidelines.
     /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names"/>
     /// </summary>
     public string ContainerName { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the cache folder name that'll store cache files under the configured container.
+    /// Must conform to Azure Blob Storage directory naming guidelines.
+    /// <see href="https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#directory-names"/>
+    /// </summary>
+    public string CacheFolder { get; set; } = null!;
 }

--- a/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
@@ -26,5 +26,5 @@ public class AzureBlobStorageCacheOptions
     /// Must conform to Azure Blob Storage directory naming guidelines.
     /// <see href="https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#directory-names"/>
     /// </summary>
-    public string CacheFolder { get; set; } = null!;
+    public string? CacheFolder { get; set; }
 }

--- a/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
+++ b/src/ImageSharp.Web.Providers.Azure/Caching/AzureBlobStorageCacheOptions.cs
@@ -22,7 +22,7 @@ public class AzureBlobStorageCacheOptions
     public string ContainerName { get; set; } = null!;
 
     /// <summary>
-    /// Gets or sets the cache folder name that'll store cache files under the configured container.
+    /// Gets or sets the cache folder's name that'll store cache files under the configured container.
     /// Must conform to Azure Blob Storage directory naming guidelines.
     /// <see href="https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#directory-names"/>
     /// </summary>

--- a/tests/ImageSharp.Web.Tests/Processing/AWSS3StorageCacheCacheFolderServerTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processing/AWSS3StorageCacheCacheFolderServerTests.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Web.Tests.TestUtilities;
+using Xunit.Abstractions;
+
+namespace SixLabors.ImageSharp.Web.Tests.Processing;
+
+public class AWSS3StorageCacheCacheFolderServerTests : ServerTestBase<AWSS3StorageCacheCacheFolderTestServerFixture>
+{
+    public AWSS3StorageCacheCacheFolderServerTests(AWSS3StorageCacheCacheFolderTestServerFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper, TestConstants.AWSTestImage)
+    {
+    }
+}

--- a/tests/ImageSharp.Web.Tests/Processing/AzureBlobStorageCacheCacheFolderServerTests.cs
+++ b/tests/ImageSharp.Web.Tests/Processing/AzureBlobStorageCacheCacheFolderServerTests.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Web.Tests.TestUtilities;
+using Xunit.Abstractions;
+
+namespace SixLabors.ImageSharp.Web.Tests.Processing;
+
+public class AzureBlobStorageCacheCacheFolderServerTests : ServerTestBase<AzureBlobStorageCacheCacheFolderTestServerFixture>
+{
+    public AzureBlobStorageCacheCacheFolderServerTests(AzureBlobStorageCacheCacheFolderTestServerFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper, TestConstants.AzureTestImage)
+    {
+    }
+}

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AWSS3StorageCacheCacheFolderTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AWSS3StorageCacheCacheFolderTestServerFixture.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using Amazon.S3;
+using Microsoft.Extensions.DependencyInjection;
+using SixLabors.ImageSharp.Web.Caching.AWS;
+using SixLabors.ImageSharp.Web.DependencyInjection;
+using SixLabors.ImageSharp.Web.Providers.AWS;
+
+namespace SixLabors.ImageSharp.Web.Tests.TestUtilities;
+
+public class AWSS3StorageCacheCacheFolderTestServerFixture : TestServerFixture
+{
+    protected override void ConfigureCustomServices(IServiceCollection services, IImageSharpBuilder builder)
+        => builder
+        .Configure<AWSS3StorageImageProviderOptions>(o =>
+            o.S3Buckets.Add(
+            new AWSS3BucketClientOptions
+            {
+                Endpoint = TestConstants.AWSEndpoint,
+                BucketName = TestConstants.AWSBucketName,
+                AccessKey = TestConstants.AWSAccessKey,
+                AccessSecret = TestConstants.AWSAccessSecret,
+                Region = TestConstants.AWSRegion,
+                Timeout = TestConstants.AWSTimeout,
+            }))
+        .AddProvider(AWSS3StorageImageProviderFactory.Create)
+        .Configure<AWSS3StorageCacheOptions>(o =>
+        {
+            o.Endpoint = TestConstants.AWSEndpoint;
+            o.BucketName = TestConstants.AWSCacheBucketName;
+            o.AccessKey = TestConstants.AWSAccessKey;
+            o.AccessSecret = TestConstants.AWSAccessSecret;
+            o.Region = TestConstants.AWSRegion;
+            o.Timeout = TestConstants.AWSTimeout;
+            o.CacheFolder = TestConstants.AWSCacheFolder;
+
+            AWSS3StorageCache.CreateIfNotExists(o, S3CannedACL.Private);
+        })
+        .SetCache<AWSS3StorageCache>();
+}

--- a/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageCacheCacheFolderTestServerFixture.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/AzureBlobStorageCacheCacheFolderTestServerFixture.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.DependencyInjection;
+using SixLabors.ImageSharp.Web.Caching.Azure;
+using SixLabors.ImageSharp.Web.DependencyInjection;
+using SixLabors.ImageSharp.Web.Providers.Azure;
+
+namespace SixLabors.ImageSharp.Web.Tests.TestUtilities;
+
+public class AzureBlobStorageCacheCacheFolderTestServerFixture : TestServerFixture
+{
+    protected override void ConfigureCustomServices(IServiceCollection services, IImageSharpBuilder builder)
+        => builder
+           .Configure<AzureBlobStorageImageProviderOptions>(o =>
+                o.BlobContainers.Add(
+                new AzureBlobContainerClientOptions
+                {
+                    ConnectionString = TestConstants.AzureConnectionString,
+                    ContainerName = TestConstants.AzureContainerName
+                }))
+            .AddProvider(AzureBlobStorageImageProviderFactory.Create)
+            .Configure<AzureBlobStorageCacheOptions>(o =>
+            {
+                o.ConnectionString = TestConstants.AzureConnectionString;
+                o.ContainerName = TestConstants.AzureCacheContainerName;
+                o.CacheFolder = TestConstants.AzureCacheFolder;
+
+                AzureBlobStorageCache.CreateIfNotExists(o, PublicAccessType.None);
+            })
+            .SetCache<AzureBlobStorageCache>();
+}

--- a/tests/ImageSharp.Web.Tests/TestUtilities/TestConstants.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/TestConstants.cs
@@ -15,6 +15,7 @@ public static class TestConstants
     public const string AWSCacheBucketName = "aws-cache";
     public const string AWSAccessKey = "";
     public const string AWSAccessSecret = "";
+    public const string AWSCacheFolder = "cache/folder";
     public const string ImagePath = "SubFolder/sîxläbörs.îmägéshärp.wéb.png";
     public const string PhysicalTestImage = "http://localhost/" + ImagePath;
     public const string AzureTestImage = "http://localhost/" + AzureContainerName + "/" + ImagePath;

--- a/tests/ImageSharp.Web.Tests/TestUtilities/TestConstants.cs
+++ b/tests/ImageSharp.Web.Tests/TestUtilities/TestConstants.cs
@@ -8,6 +8,7 @@ public static class TestConstants
     public const string AzureConnectionString = "UseDevelopmentStorage=true";
     public const string AzureContainerName = "azure";
     public const string AzureCacheContainerName = "is-cache";
+    public const string AzureCacheFolder = "cache/folder";
     public const string AWSEndpoint = "http://localhost:4568/";
     public const string AWSRegion = "eu-west-2";
     public const string AWSBucketName = "aws";


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
For multi-tenancy scenarios and for feature parity with `PhysicalFileSystemCache`, this PR adds a `CacheFolder` configuration for the Azure and AWS Image Caches

Please see https://github.com/SixLabors/ImageSharp.Web/discussions/351 for more details, especially the rationale.

There are two things I'm unsure about, please advise:

1. Tests: My usual approach in such cases would be to turn the test into a `Theory` with input parameters, and run the test once without setting `CacheFolder`, and then once with it. In this test suite, I don't really see how to approach this; I could add another class like `AzureBlobStorageCacheTestServerFixture` where the new property is set, but that seems like the wrong approach. Same for `AWSS3StorageCacheTestServerFixture`. What should I do? I've run the tests with the `CacheFolder`s set and they still pass BTW.
2. For AWS, I added the new property only to `AWSS3StorageCacheOptions` instead of also to `IAWSS3BucketClientOptions`, since the scope of https://github.com/SixLabors/ImageSharp.Web/discussions/351 is about caching only. Should I do anything differently?

See the related docs PR: https://github.com/SixLabors/docs/pull/65.

Thank you!
<!-- Thanks for contributing to ImageSharp! -->
