### PR TITLE
Ensure invalid path extensions are skipped when validating input URLs

### DIFF
--- a/samples/ImageSharp.Web.Sample/Pages/Index.cshtml
+++ b/samples/ImageSharp.Web.Sample/Pages/Index.cshtml
@@ -52,10 +52,10 @@
         </div>
         <div>
             <p>
-                <code>sixlabors.imagesharp.web.svg?width=300</code>
+                <code>sixlabors.imagesharp.web.svg?width=300&format=jpg</code>
             </p>
             <p>
-                <img src="sixlabors.imagesharp.web.svg" imagesharp-width="300" />
+            <img src="sixlabors.imagesharp.web.svg" imagesharp-width="300" imagesharp-format="Format.Jpg" />
             </p>
         </div>
     </section>

--- a/src/ImageSharp.Web/FormatUtilities.cs
+++ b/src/ImageSharp.Web/FormatUtilities.cs
@@ -53,12 +53,19 @@ public sealed class FormatUtilities
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryGetExtensionFromUri(string uri, [NotNullWhen(true)] out string? extension)
     {
+        // Attempts to extract a valid image file extension from the URI.
+        // If the path contains a recognized extension, it is used.
+        // If the path lacks an extension and a query string is present,
+        // the method checks for a valid 'format' parameter as a fallback.
+        // Returns true if a supported extension is found in either location.
         extension = null;
         int query = uri.IndexOf('?');
         ReadOnlySpan<char> path;
 
         if (query > -1)
         {
+            path = uri.AsSpan(0, query);
+
             if (uri.Contains(FormatWebProcessor.Format, StringComparison.OrdinalIgnoreCase)
                 && QueryHelpers.ParseQuery(uri[query..]).TryGetValue(FormatWebProcessor.Format, out StringValues ext))
             {
@@ -68,15 +75,13 @@ public sealed class FormatUtilities
                 {
                     if (extSpan.Equals(e, StringComparison.OrdinalIgnoreCase))
                     {
+                        // We've found a valid extension in the query.
+                        // Now we need to check the path to see if there is a file extension and validate that.
                         extension = e;
-                        return true;
+                        break;
                     }
                 }
-
-                return false;
             }
-
-            path = uri.AsSpan(0, query);
         }
         else
         {
@@ -96,9 +101,11 @@ public sealed class FormatUtilities
                     return true;
                 }
             }
+
+            return false;
         }
 
-        return false;
+        return extension != null;
     }
 
     /// <summary>

--- a/src/ImageSharp.Web/FormatUtilities.cs
+++ b/src/ImageSharp.Web/FormatUtilities.cs
@@ -88,21 +88,25 @@ public sealed class FormatUtilities
             path = uri;
         }
 
-        int extensionIndex;
-        if ((extensionIndex = path.LastIndexOf('.')) != -1)
+        // We don't need this if the query string has already provided a valid extension.
+        if (extension == null)
         {
-            ReadOnlySpan<char> pathExtension = path[(extensionIndex + 1)..];
-
-            foreach (string e in this.extensions)
+            int extensionIndex;
+            if ((extensionIndex = path.LastIndexOf('.')) != -1)
             {
-                if (pathExtension.Equals(e, StringComparison.OrdinalIgnoreCase))
-                {
-                    extension = e;
-                    return true;
-                }
-            }
+                ReadOnlySpan<char> pathExtension = path[(extensionIndex + 1)..];
 
-            return false;
+                foreach (string e in this.extensions)
+                {
+                    if (pathExtension.Equals(e, StringComparison.OrdinalIgnoreCase))
+                    {
+                        extension = e;
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
 
         return extension != null;

--- a/src/ImageSharp.Web/FormatUtilities.cs
+++ b/src/ImageSharp.Web/FormatUtilities.cs
@@ -88,25 +88,23 @@ public sealed class FormatUtilities
             path = uri;
         }
 
-        // We don't need this if the query string has already provided a valid extension.
-        if (extension == null)
+        int extensionIndex;
+        if ((extensionIndex = path.LastIndexOf('.')) != -1)
         {
-            int extensionIndex;
-            if ((extensionIndex = path.LastIndexOf('.')) != -1)
+            ReadOnlySpan<char> pathExtension = path[(extensionIndex + 1)..];
+
+            foreach (string e in this.extensions)
             {
-                ReadOnlySpan<char> pathExtension = path[(extensionIndex + 1)..];
-
-                foreach (string e in this.extensions)
+                if (pathExtension.Equals(e, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (pathExtension.Equals(e, StringComparison.OrdinalIgnoreCase))
-                    {
-                        extension = e;
-                        return true;
-                    }
+                    // We've found a valid extension in the path, however we do not
+                    // want to overwrite an existing extension.
+                    extension ??= e;
+                    return true;
                 }
-
-                return false;
             }
+
+            return false;
         }
 
         return extension != null;

--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/tests/ImageSharp.Web.Tests/Helpers/FormatUtilitiesTests.cs
+++ b/tests/ImageSharp.Web.Tests/Helpers/FormatUtilitiesTests.cs
@@ -51,4 +51,11 @@ public class FormatUtilitiesTests
         const string uri = "http://www.example.org/some/path/to/image.bmp?width=300&format=invalid";
         Assert.False(FormatUtilities.TryGetExtensionFromUri(uri, out _));
     }
+
+    [Fact]
+    public void GetExtensionShouldRejectInvalidPathWithValidQueryStringFormatParameter()
+    {
+        const string uri = "http://www.example.org/some/path/to/image.svg?width=300&format=jpg";
+        Assert.False(FormatUtilities.TryGetExtensionFromUri(uri, out _));
+    }
 }

--- a/tests/ImageSharp.Web.Tests/Helpers/FormatUtilitiesTests.cs
+++ b/tests/ImageSharp.Web.Tests/Helpers/FormatUtilitiesTests.cs
@@ -46,10 +46,10 @@ public class FormatUtilitiesTests
     }
 
     [Fact]
-    public void GetExtensionShouldRejectInvalidQueryStringFormatParameter()
+    public void GetExtensionShouldAllowInvalidQueryStringFormatParameterWithValidExtension()
     {
         const string uri = "http://www.example.org/some/path/to/image.bmp?width=300&format=invalid";
-        Assert.False(FormatUtilities.TryGetExtensionFromUri(uri, out _));
+        Assert.True(FormatUtilities.TryGetExtensionFromUri(uri, out _));
     }
 
     [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Fixes #233 

<!-- Thanks for contributing to ImageSharp! -->
