### PR TITLE
Bump ImageSharp and adjust auto-orient logic

### DIFF
--- a/src/ImageSharp.Web/ImageSharp.Web.csproj
+++ b/src/ImageSharp.Web/ImageSharp.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyTitle>SixLabors.ImageSharp.Web</AssemblyTitle>
@@ -46,7 +46,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0-alpha.0.88" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0-alpha.0.107" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
+++ b/src/ImageSharp.Web/Middleware/ImageSharpMiddlewareOptions.cs
@@ -38,7 +38,7 @@ public class ImageSharpMiddlewareOptions
         // https://zpl.fi/exif-orientation-in-different-formats/
         // To ensure that orientation is handled correctly for web use we transparently add the auto-orient command if it is not already present.
         // See issues #304, #375, and #381 for more details.
-        if (!context.Commands.Contains(AutoOrientWebProcessor.AutoOrient))
+        if (context.Commands.Count > 0 && !context.Commands.Contains(AutoOrientWebProcessor.AutoOrient))
         {
             context.Commands.Insert(0, new KeyValuePair<string, string?>(AutoOrientWebProcessor.AutoOrient, bool.TrueString));
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Web/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request primarily updates dependencies and makes a minor logic improvement in the `ImageSharpMiddlewareOptions` class. The most important changes are:

**Dependency Updates:**

* Upgraded the `SixLabors.ImageSharp` package dependency.
* Updated the `shared-infrastructure` submodule to a newer commit, which may include various upstream changes or fixes.

**Middleware Logic Improvement:**

* Improved the logic for auto-orienting images in `ImageSharpMiddlewareOptions.cs` by ensuring the auto-orient command is only added if there are existing commands, preventing unnecessary insertion when the command list is empty.

<!-- Thanks for contributing to ImageSharp! -->
